### PR TITLE
Add support for specifying the unpacked size outside of header

### DIFF
--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -4,6 +4,9 @@ use crate::decode::rangecoder;
 use crate::error;
 use std::io;
 
+use crate::decompress::Options;
+use crate::decompress::UnpackedSize;
+
 pub struct LZMAParams {
     // most lc significant bits of previous byte are part of the literal context
     lc: u32, // 0..8
@@ -15,7 +18,7 @@ pub struct LZMAParams {
 }
 
 impl LZMAParams {
-    pub fn read_header<R>(input: &mut R) -> error::Result<LZMAParams>
+    pub fn read_header<R>(input: &mut R, options: &Options) -> error::Result<LZMAParams>
     where
         R: io::BufRead,
     {
@@ -58,17 +61,26 @@ impl LZMAParams {
         info!("Dict size: {}", dict_size);
 
         // Unpacked size
-        let unpacked_size_provided = input.read_u64::<LittleEndian>().or_else(|e| {
-            Err(error::Error::LZMAError(format!(
-                "LZMA header too short: {}",
-                e
-            )))
-        })?;
-        let marker_mandatory: bool = unpacked_size_provided == 0xFFFF_FFFF_FFFF_FFFF;
-        let unpacked_size = if marker_mandatory {
-            None
-        } else {
-            Some(unpacked_size_provided)
+        let unpacked_size: Option<u64> = match options.unpacked_size {
+            UnpackedSize::ReadHeaderAndUseHeader => {
+                let unpacked_size_provided = input.read_u64::<LittleEndian>().or_else(|e| {
+                    Err(error::Error::LZMAError(format!(
+                        "LZMA header too short: {}",
+                        e
+                    )))
+                })?;
+                let marker_mandatory: bool = unpacked_size_provided == 0xFFFF_FFFF_FFFF_FFFF;
+                if marker_mandatory {
+                    None
+                } else {
+                    Some(unpacked_size_provided)
+                }
+            },
+            UnpackedSize::ReadHeaderButUseProvided(x) => {
+                input.read_u64::<LittleEndian>()?;
+                x
+            }
+            UnpackedSize::SkipHeaderAndUseProvided(x) => x
         };
 
         info!("Unpacked size: {:?}", unpacked_size);

--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -62,7 +62,7 @@ impl LZMAParams {
 
         // Unpacked size
         let unpacked_size: Option<u64> = match options.unpacked_size {
-            UnpackedSize::ReadHeaderAndUseHeader => {
+            UnpackedSize::ReadFromHeader => {
                 let unpacked_size_provided = input.read_u64::<LittleEndian>().or_else(|e| {
                     Err(error::Error::LZMAError(format!(
                         "LZMA header too short: {}",
@@ -80,7 +80,7 @@ impl LZMAParams {
                 input.read_u64::<LittleEndian>()?;
                 x
             }
-            UnpackedSize::SkipHeaderAndUseProvided(x) => x
+            UnpackedSize::UseProvided(x) => x
         };
 
         info!("Unpacked size: {:?}", unpacked_size);

--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -75,12 +75,12 @@ impl LZMAParams {
                 } else {
                     Some(unpacked_size_provided)
                 }
-            },
+            }
             UnpackedSize::ReadHeaderButUseProvided(x) => {
                 input.read_u64::<LittleEndian>()?;
                 x
             }
-            UnpackedSize::UseProvided(x) => x
+            UnpackedSize::UseProvided(x) => x,
         };
 
         info!("Unpacked size: {:?}", unpacked_size);

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,6 +1,7 @@
 pub mod lzbuffer;
 pub mod lzma;
 pub mod lzma2;
+pub mod options;
 pub mod rangecoder;
 pub mod util;
 pub mod xz;

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -1,4 +1,4 @@
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be read from the header or provided.
     /// The default is
@@ -7,6 +7,7 @@ pub struct Options {
 }
 
 /// Alternatives for defining the unpacked size of the decoded data
+#[derive(Clone, Debug)]
 pub enum UnpackedSize {
     /// Assume that the 8 bytes used to specify the unpacked size are present in the header.
     /// If the bytes are `0xFFFF_FFFF_FFFF_FFFF`, assume that there is an end-of-payload marker in

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -1,7 +1,8 @@
 #[derive(Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be read from the header or provided.
-    /// The default is [`UnpackedSize::ReadHeaderAndUseHeader`](enum.UnpackedSize.html#variant.ReadHeaderAndUseHeader)
+    /// The default is
+    /// [`UnpackedSize::ReadFromHeader`](enum.UnpackedSize.html#variant.ReadFromHeader)
     pub unpacked_size: UnpackedSize,
 }
 
@@ -11,22 +12,23 @@ pub enum UnpackedSize {
     /// If the bytes are `0xFFFF_FFFF_FFFF_FFFF`, assume that there is an end-of-payload marker in
     /// the file.
     /// If not, read the 8 bytes as a little-endian encoded u64.
-    ReadHeaderAndUseHeader,
+    ReadFromHeader,
     /// Assume that there are 8 bytes representing the unpacked size present in the header.
     /// Read it, but ignore it and use the provided value instead.
     /// If the provided value is `None`, assume that there is an end-of-payload marker in the file.
     /// Note that this is a non-standard way of reading LZMA data,
-    /// but is used by certain libraries such as OpenCTM.
+    /// but is used by certain libraries such as
+    /// [OpenCTM](http://openctm.sourceforge.net/).
     ReadHeaderButUseProvided(Option<u64>),
     /// Assume that the 8 bytes typically used to represent the unpacked size are *not* present in
     /// the header. Use the provided value.
     /// If the provided value is `None`, assume that there is an end-of-payload marker in the file.
-    SkipHeaderAndUseProvided(Option<u64>),
+    UseProvided(Option<u64>),
 }
 
 impl Default for UnpackedSize {
     fn default() -> UnpackedSize {
-        UnpackedSize::ReadHeaderAndUseHeader
+        UnpackedSize::ReadFromHeader
     }
 }
 

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be read from the header or provided.
     /// The default is
@@ -7,7 +7,7 @@ pub struct Options {
 }
 
 /// Alternatives for defining the unpacked size of the decoded data
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum UnpackedSize {
     /// Assume that the 8 bytes used to specify the unpacked size are present in the header.
     /// If the bytes are `0xFFFF_FFFF_FFFF_FFFF`, assume that there is an end-of-payload marker in

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -1,0 +1,32 @@
+#[derive(Default)]
+pub struct Options {
+    /// Defines whether the unpacked size should be read from the header or provided.
+    /// The default is [`UnpackedSize::ReadHeaderAndUseHeader`](enum.UnpackedSize.html#variant.ReadHeaderAndUseHeader)
+    pub unpacked_size: UnpackedSize,
+}
+
+/// Alternatives for defining the unpacked size of the decoded data
+pub enum UnpackedSize {
+    /// Assume that the 8 bytes used to specify the unpacked size are present in the header.
+    /// If the bytes are `0xFFFF_FFFF_FFFF_FFFF`, assume that there is an end-of-payload marker in
+    /// the file.
+    /// If not, read the 8 bytes as a little-endian encoded u64.
+    ReadHeaderAndUseHeader,
+    /// Assume that there are 8 bytes representing the unpacked size present in the header.
+    /// Read it, but ignore it and use the provided value instead.
+    /// If the provided value is `None`, assume that there is an end-of-payload marker in the file.
+    /// Note that this is a non-standard way of reading LZMA data,
+    /// but is used by certain libraries such as OpenCTM.
+    ReadHeaderButUseProvided(Option<u64>),
+    /// Assume that the 8 bytes typically used to represent the unpacked size are *not* present in
+    /// the header. Use the provided value.
+    /// If the provided value is `None`, assume that there is an end-of-payload marker in the file.
+    SkipHeaderAndUseProvided(Option<u64>),
+}
+
+impl Default for UnpackedSize {
+    fn default() -> UnpackedSize {
+        UnpackedSize::ReadHeaderAndUseHeader
+    }
+}
+

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -32,4 +32,3 @@ impl Default for UnpackedSize {
         UnpackedSize::ReadFromHeader
     }
 }
-

--- a/src/encode/dumbencoder.rs
+++ b/src/encode/dumbencoder.rs
@@ -55,7 +55,7 @@ where
             rangecoder: rangecoder::RangeEncoder::new(stream),
             literal_probs: [[0x400; 0x300]; 8],
             is_match: [0x400; 4],
-            unpacked_size: options.unpacked_size.clone(),
+            unpacked_size: options.unpacked_size,
         };
 
         Ok(encoder)

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -1,5 +1,6 @@
 pub mod dumbencoder;
 pub mod lzma2;
+pub mod options;
 mod rangecoder;
 mod util;
 pub mod xz;

--- a/src/encode/options.rs
+++ b/src/encode/options.rs
@@ -1,8 +1,7 @@
 /// Options for the `lzma_compress` function
 #[derive(Default)]
 pub struct Options {
-    /// Defines whether the unpacked size should be written to the header and whether the value is
-    /// known.
+    /// Defines whether the unpacked size should be written to the header.
     /// The default is
     /// [`UnpackedSize::WriteToHeader(None)`](enum.encode.UnpackedSize.html#variant.WriteValueToHeader)
     pub unpacked_size: UnpackedSize,
@@ -11,13 +10,15 @@ pub struct Options {
 /// Alternatives for handling unpacked size
 pub enum UnpackedSize {
     /// If the value is `Some(u64)`, write the provided u64 value to the header.
-    /// There is currently no check in place that verifies that this is the actual number of bytes provided by the input stream.
+    /// There is currently no check in place that verifies that this is the actual number of bytes
+    /// provided by the input stream.
     /// If the value is `None`, write the special `0xFFFF_FFFF_FFFF_FFFF` code to the header,
     /// indicating that the unpacked size is unknown.
     WriteToHeader(Option<u64>),
     /// Do not write anything to the header. The unpacked size needs to be stored elsewhere and
     /// provided when reading the file. Note that this is a non-standard way of writing LZMA data,
-    /// but is used by certain libraries such as OpenCTM.
+    /// but is used by certain libraries such as
+    /// [OpenCTM](http://openctm.sourceforge.net/).
     SkipWritingToHeader,
 }
 

--- a/src/encode/options.rs
+++ b/src/encode/options.rs
@@ -1,0 +1,28 @@
+/// Options for the `lzma_compress` function
+#[derive(Default)]
+pub struct Options {
+    /// Defines whether the unpacked size should be written to the header and whether the value is
+    /// known.
+    /// The default is
+    /// [`UnpackedSize::WriteToHeader(None)`](enum.encode.UnpackedSize.html#variant.WriteValueToHeader)
+    pub unpacked_size: UnpackedSize,
+}
+
+/// Alternatives for handling unpacked size
+pub enum UnpackedSize {
+    /// If the value is `Some(u64)`, write the provided u64 value to the header.
+    /// There is currently no check in place that verifies that this is the actual number of bytes provided by the input stream.
+    /// If the value is `None`, write the special `0xFFFF_FFFF_FFFF_FFFF` code to the header,
+    /// indicating that the unpacked size is unknown.
+    WriteToHeader(Option<u64>),
+    /// Do not write anything to the header. The unpacked size needs to be stored elsewhere and
+    /// provided when reading the file. Note that this is a non-standard way of writing LZMA data,
+    /// but is used by certain libraries such as OpenCTM.
+    SkipWritingToHeader,
+}
+
+impl Default for UnpackedSize {
+    fn default() -> UnpackedSize {
+        UnpackedSize::WriteToHeader(None)
+    }
+}

--- a/src/encode/options.rs
+++ b/src/encode/options.rs
@@ -1,5 +1,5 @@
 /// Options for the `lzma_compress` function
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be written to the header.
     /// The default is
@@ -8,7 +8,7 @@ pub struct Options {
 }
 
 /// Alternatives for handling unpacked size
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum UnpackedSize {
     /// If the value is `Some(u64)`, write the provided u64 value to the header.
     /// There is currently no check in place that verifies that this is the actual number of bytes

--- a/src/encode/options.rs
+++ b/src/encode/options.rs
@@ -1,5 +1,5 @@
 /// Options for the `lzma_compress` function
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be written to the header.
     /// The default is
@@ -8,6 +8,7 @@ pub struct Options {
 }
 
 /// Alternatives for handling unpacked size
+#[derive(Clone, Debug)]
 pub enum UnpackedSize {
     /// If the value is `Some(u64)`, write the provided u64 value to the header.
     /// There is currently no check in place that verifies that this is the actual number of bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,29 @@ pub mod error;
 use crate::decode::lzbuffer::LZBuffer;
 use std::io;
 
+pub mod compress {
+    pub use crate::encode::options::*;
+}
+
+pub mod decompress {
+    pub use crate::decode::options::*;
+}
+
+/// Decompress LZMA data with default [`Options`](decompress/struct.Options.html).
 pub fn lzma_decompress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
 ) -> error::Result<()> {
-    let params = decode::lzma::LZMAParams::read_header(input)?;
+    lzma_decompress_with_options(input, output, &decompress::Options::default())
+}
+
+/// Decompress LZMA data with the provided options
+pub fn lzma_decompress_with_options<R: io::BufRead, W: io::Write>(
+    input: &mut R,
+    output: &mut W,
+    options: &decompress::Options,
+) -> error::Result<()> {
+    let params = decode::lzma::LZMAParams::read_header(input, &options)?;
     let mut decoder = decode::lzma::new_circular(output, params)?;
     let mut rangecoder = decode::rangecoder::RangeDecoder::new(input).or_else(|e| {
         Err(error::Error::LZMAError(format!(
@@ -27,11 +45,20 @@ pub fn lzma_decompress<R: io::BufRead, W: io::Write>(
     Ok(())
 }
 
+/// Compresses the data with default [`Options`](compress/struct.Options.html).
 pub fn lzma_compress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
 ) -> io::Result<()> {
-    let encoder = encode::dumbencoder::Encoder::from_stream(output)?;
+    lzma_compress_with_options(input, output, &compress::Options::default())
+}
+
+pub fn lzma_compress_with_options<R: io::BufRead, W: io::Write>(
+    input: &mut R,
+    output: &mut W,
+    options: &compress::Options,
+) -> io::Result<()> {
+    let encoder = encode::dumbencoder::Encoder::from_stream(output, options)?;
     encoder.process(input)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,13 @@ pub fn lzma_decompress<R: io::BufRead, W: io::Write>(
     lzma_decompress_with_options(input, output, &decompress::Options::default())
 }
 
-/// Decompress LZMA data with the provided options
+/// Decompress LZMA data with the provided options.
 pub fn lzma_decompress_with_options<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
     options: &decompress::Options,
 ) -> error::Result<()> {
-    let params = decode::lzma::LZMAParams::read_header(input, &options)?;
+    let params = decode::lzma::LZMAParams::read_header(input, options)?;
     let mut decoder = decode::lzma::new_circular(output, params)?;
     let mut rangecoder = decode::rangecoder::RangeDecoder::new(input).or_else(|e| {
         Err(error::Error::LZMAError(format!(

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -163,18 +163,6 @@ fn unpacked_size_provided_outside() {
 }
 
 #[test]
-fn unpacked_size_provided_outside_as_none() {
-    let data = b"Some data";
-    let encode_options = lzma_rs::compress::Options {
-        unpacked_size: lzma_rs::compress::UnpackedSize::SkipWritingToHeader,
-    };
-    let decode_options = lzma_rs::decompress::Options {
-        unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(None),
-    };
-    round_trip_with_options(&data[..], &encode_options, &decode_options);
-}
-
-#[test]
 fn unpacked_size_write_some_to_header_but_use_provided_on_read() {
     let data = b"Some data";
     let encode_options = lzma_rs::compress::Options {
@@ -200,20 +188,6 @@ fn unpacked_size_write_none_to_header_and_use_provided_on_read() {
         unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(Some(
             data.len() as u64,
         )),
-    };
-    round_trip_with_options(&data[..], &encode_options, &decode_options);
-}
-
-#[test]
-fn unpacked_size_write_some_to_header_but_use_provided_none_on_read() {
-    let data = b"Some data";
-    let encode_options = lzma_rs::compress::Options {
-        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(
-            Some(data.len() as u64),
-        ),
-    };
-    let decode_options = lzma_rs::decompress::Options {
-        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(None),
     };
     round_trip_with_options(&data[..], &encode_options, &decode_options);
 }

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -14,6 +14,26 @@ fn round_trip(x: &[u8]) {
     assert_eq!(decomp, x)
 }
 
+fn round_trip_with_options(
+    x: &[u8],
+    encode_options: &lzma_rs::compress::Options,
+    decode_options: &lzma_rs::decompress::Options,
+) {
+    let mut compressed: Vec<u8> = Vec::new();
+    lzma_rs::lzma_compress_with_options(
+        &mut std::io::BufReader::new(x),
+        &mut compressed,
+        encode_options,
+    )
+    .unwrap();
+    info!("Compressed {} -> {} bytes", x.len(), compressed.len());
+    debug!("Compressed content: {:?}", compressed);
+    let mut bf = std::io::BufReader::new(compressed.as_slice());
+    let mut decomp: Vec<u8> = Vec::new();
+    lzma_rs::lzma_decompress_with_options(&mut bf, &mut decomp, decode_options).unwrap();
+    assert_eq!(decomp, x)
+}
+
 fn round_trip_file(filename: &str) {
     use std::io::Read;
 
@@ -112,4 +132,62 @@ fn decompress_huge_dict() {
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma_decompress(&mut x, &mut decomp).unwrap();
     assert_eq!(decomp, b"Hello world\x0a")
+}
+
+#[test]
+fn unpacked_size_write_to_header() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(
+            Some(data.len() as u64),
+        ),
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderAndUseHeader,
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
+}
+
+#[test]
+fn unpacked_size_provided_outside() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::SkipWritingToHeader,
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::SkipHeaderAndUseProvided(Some(
+            data.len() as u64,
+        )),
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
+}
+
+#[test]
+fn unpacked_size_write_some_to_header_but_use_provided_on_read() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(
+            Some(data.len() as u64),
+        ),
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(Some(
+            data.len() as u64,
+        )),
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
+}
+
+#[test]
+fn unpacked_size_write_none_to_header_and_use_provided_on_read() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(None),
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(Some(
+            data.len() as u64,
+        )),
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
 }

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -143,7 +143,7 @@ fn unpacked_size_write_to_header() {
         ),
     };
     let decode_options = lzma_rs::decompress::Options {
-        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderAndUseHeader,
+        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadFromHeader,
     };
     round_trip_with_options(&data[..], &encode_options, &decode_options);
 }
@@ -155,9 +155,21 @@ fn unpacked_size_provided_outside() {
         unpacked_size: lzma_rs::compress::UnpackedSize::SkipWritingToHeader,
     };
     let decode_options = lzma_rs::decompress::Options {
-        unpacked_size: lzma_rs::decompress::UnpackedSize::SkipHeaderAndUseProvided(Some(
+        unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(Some(
             data.len() as u64,
         )),
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
+}
+
+#[test]
+fn unpacked_size_provided_outside_as_none() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::SkipWritingToHeader,
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(None),
     };
     round_trip_with_options(&data[..], &encode_options, &decode_options);
 }
@@ -188,6 +200,32 @@ fn unpacked_size_write_none_to_header_and_use_provided_on_read() {
         unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(Some(
             data.len() as u64,
         )),
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
+}
+
+#[test]
+fn unpacked_size_write_some_to_header_but_use_provided_none_on_read() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(
+            Some(data.len() as u64),
+        ),
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(None),
+    };
+    round_trip_with_options(&data[..], &encode_options, &decode_options);
+}
+
+#[test]
+fn unpacked_size_write_none_to_header_and_use_provided_none_on_read() {
+    let data = b"Some data";
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(None),
+    };
+    let decode_options = lzma_rs::decompress::Options {
+        unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(None),
     };
     round_trip_with_options(&data[..], &encode_options, &decode_options);
 }

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -138,9 +138,7 @@ fn decompress_huge_dict() {
 fn unpacked_size_write_to_header() {
     let data = b"Some data";
     let encode_options = lzma_rs::compress::Options {
-        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(
-            Some(data.len() as u64),
-        ),
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(Some(data.len() as u64)),
     };
     let decode_options = lzma_rs::decompress::Options {
         unpacked_size: lzma_rs::decompress::UnpackedSize::ReadFromHeader,
@@ -155,9 +153,7 @@ fn unpacked_size_provided_outside() {
         unpacked_size: lzma_rs::compress::UnpackedSize::SkipWritingToHeader,
     };
     let decode_options = lzma_rs::decompress::Options {
-        unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(Some(
-            data.len() as u64,
-        )),
+        unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(Some(data.len() as u64)),
     };
     round_trip_with_options(&data[..], &encode_options, &decode_options);
 }
@@ -166,9 +162,7 @@ fn unpacked_size_provided_outside() {
 fn unpacked_size_write_some_to_header_but_use_provided_on_read() {
     let data = b"Some data";
     let encode_options = lzma_rs::compress::Options {
-        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(
-            Some(data.len() as u64),
-        ),
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(Some(data.len() as u64)),
     };
     let decode_options = lzma_rs::decompress::Options {
         unpacked_size: lzma_rs::decompress::UnpackedSize::ReadHeaderButUseProvided(Some(


### PR DESCRIPTION
Some LZMA streams, such as those used in OpenCTM, are encoded without
the unpacked size specified in the header. This is possible to read in
some of the C implementations of LZMA by specifying a header size and
providing the unpacked size as an option to the decoder.

This change adds the same possibility to lzma_rs in a typesafe manner,
where the unpacked size and whether it should be written to the header
is specified explicitly.

### Pull Request Overview

This pull request adds `Options` objects to two new public modules named `compress` and `decompress` that can be used to specify whether the unpacked size should be written to and read from the LZMA header.

### Testing Strategy

This pull request was tested by...

- [x] Added relevant unit tests.
- [ ] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).


### Supporting Documentation and References

This exotic use of the LZMA header is only indicated in the [OpenCTM specification itself](http://openctm.sourceforge.net/media/FormatSpecification.pdf), where it specifically states that the offset of the stream [is only 9 bytes](https://github.com/Danny02/OpenCTM/blob/243a343bd23bbeef8731f06ed91e3996604e1af4/doc/FormatSpecification.tex#L91), while it should have been 17 bytes with the unpacked size in place. This is based on 4 bytes from OpenCTM itself, 1 byte for the props, 4 bytes for the dict size and the missing 8 bytes for the unpacked size.

It can also be seen from the OpenCTM source code that the LZMA header written is only 5 bytes:

https://github.com/Danny02/OpenCTM/blob/243a343bd23bbeef8731f06ed91e3996604e1af4/lib/stream.c#L311

### TODO or Help Wanted

This pull request still needs a bit of bikeshedding on the names of the modules and enums used in the options :)
