### PR TITLE
Fix .travis.yml for Bors integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,21 @@ rust:
 matrix:
     allow_failures:
         - rust: nightly
+# bors default configuration:
+#branches:
+#  only:
+#    # This is where pull requests from "bors r+" are built.
+#    - staging
+#    # This is where pull requests from "bors try" are built.
+#    - trying
+#    # Uncomment this to enable building pull requests.
+#    #- master
+#
+# Instead, we can just disable bors temporary branches.
+branches:
+  except:
+    - staging.tmp
+    - trying.tmp
 before_script:
     - rustup component add rustfmt
 script:


### PR DESCRIPTION
This caused failed builds such as https://travis-ci.org/gendx/lzma-rs/builds/625903286