### PR TITLE
Do not allocate buffer size before necessary

### DIFF
--- a/src/decode/lzbuffer.rs
+++ b/src/decode/lzbuffer.rs
@@ -138,7 +138,7 @@ where
     pub fn from_stream(stream: &'a mut W, dict_size: usize) -> Self {
         info!("Dict size in LZ buffer: {}", dict_size);
         Self {
-            stream: stream,
+            stream,
             buf: Vec::new(),
             dict_size,
             cursor: 0,
@@ -147,14 +147,13 @@ where
     }
 
     fn get(&self, index: usize) -> u8 {
-        match self.buf.get(index) {
-            Some(x) => *x,
-            None => 0,
-        }
+        *self.buf.get(index).unwrap_or(&0)
     }
 
     fn get_mut(&mut self, index: usize) -> &mut u8 {
-        self.buf.resize(index + 1, 0);
+        if self.buf.len() < index + 1 {
+            self.buf.resize(index + 1, 0);
+        }
         self.buf.get_mut(index).unwrap()
     }
 }

--- a/src/decode/lzbuffer.rs
+++ b/src/decode/lzbuffer.rs
@@ -138,12 +138,24 @@ where
     pub fn from_stream(stream: &'a mut W, dict_size: usize) -> Self {
         info!("Dict size in LZ buffer: {}", dict_size);
         Self {
-            stream,
-            buf: vec![0; dict_size],
+            stream: stream,
+            buf: Vec::new(),
             dict_size,
             cursor: 0,
             len: 0,
         }
+    }
+
+    fn get(&self, index: usize) -> u8 {
+        match self.buf.get(index) {
+            Some(x) => *x,
+            None => 0,
+        }
+    }
+
+    fn get_mut(&mut self, index: usize) -> &mut u8 {
+        self.buf.resize(index + 1, 0);
+        self.buf.get_mut(index).unwrap()
     }
 }
 
@@ -160,7 +172,7 @@ where
         if self.len == 0 {
             lit
         } else {
-            self.buf[(self.dict_size + self.cursor - 1) % self.dict_size]
+            self.get((self.dict_size + self.cursor - 1) % self.dict_size)
         }
     }
 
@@ -180,12 +192,12 @@ where
         }
 
         let offset = (self.dict_size + self.cursor - dist) % self.dict_size;
-        Ok(self.buf[offset])
+        Ok(self.get(offset))
     }
 
     // Append a literal
     fn append_literal(&mut self, lit: u8) -> io::Result<()> {
-        self.buf[self.cursor] = lit;
+        *self.get_mut(self.cursor) = lit;
         self.cursor += 1;
         self.len += 1;
 
@@ -216,7 +228,7 @@ where
 
         let mut offset = (self.dict_size + self.cursor - dist) % self.dict_size;
         for _ in 0..len {
-            let x = self.buf[offset];
+            let x = self.get(offset);
             self.append_literal(x)?;
             offset += 1;
             if offset == self.dict_size {


### PR DESCRIPTION
This changes the way the LZCircularBuffer is allocated. Instead of allocating the full dict size immediately, the buffer is grown on demand. This helps when parsing smaller files with large dict sizes, especially when compiling to WebAssembly and running in browser where `alloc_zeroed` is slow.