### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate byteorder;
 #[cfg(feature = "enable_logging")]
 #[macro_use]


### PR DESCRIPTION
### Pull Request Overview

Add `#![forbid(unsafe_code)]` which turns `unsafe` blocks into compile-time errors. This does two things:

1. Signals preference for safe code to contributors 
2. allows tools such as [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger) to be sure that no unsafe code is present, and they didn't accidentally miss it.

### Testing Strategy

 - Code still compiles
 - `cargo-geiger` recognizes presence of the attribute

### Supporting Documentation and References

https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html describes the attribute

### TODO or Help Wanted

None
