### PR TITLE
lib: remove spurious extern statements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,5 @@
 #![forbid(unsafe_code)]
 
-extern crate byteorder;
-#[cfg(feature = "enable_logging")]
-#[macro_use]
-extern crate log;
-extern crate crc;
-
 #[macro_use]
 mod macros;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 macro_rules! lzma_trace {
     ($($arg:tt)+) => {
-        trace!($($arg)+);
+        log::trace!($($arg)+);
     }
 }
 
@@ -10,7 +10,7 @@ macro_rules! lzma_trace {
 #[macro_export]
 macro_rules! lzma_debug {
     ($($arg:tt)+) => {
-        debug!($($arg)+);
+        log::debug!($($arg)+);
     }
 }
 
@@ -18,7 +18,7 @@ macro_rules! lzma_debug {
 #[macro_export]
 macro_rules! lzma_info {
     ($($arg:tt)+) => {
-        info!($($arg)+);
+        log::info!($($arg)+);
     }
 }
 


### PR DESCRIPTION
This removes `extern crate` statements, not required on 2018 edition.
