### PR TITLE
decode/xz: do not panic on unsupported checksum

### DIFF
--- a/src/decode/xz.rs
+++ b/src/decode/xz.rs
@@ -361,7 +361,11 @@ where
             }
         }
         // TODO
-        CheckMethod::SHA256 => unimplemented!(),
+        CheckMethod::SHA256 => {
+            return Err(error::Error::XZError(
+                "Unsupported SHA-256 checksum (not yet implemented)".to_string(),
+            ));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
This returns an error when trying to decode inputs with an unsupported
SHA-256 checksum, instead of panicking.

Closes: https://github.com/gendx/lzma-rs/issues/32

