### PR TITLE
lib: add missing docstrings

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,3 +1,5 @@
+//! Decoding logic.
+
 pub mod lzbuffer;
 pub mod lzma;
 pub mod lzma2;

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -1,12 +1,14 @@
+/// Options to tweak decompression behavior.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be read from the header or provided.
+    ///
     /// The default is
-    /// [`UnpackedSize::ReadFromHeader`](enum.UnpackedSize.html#variant.ReadFromHeader)
+    /// [`UnpackedSize::ReadFromHeader`](enum.UnpackedSize.html#variant.ReadFromHeader).
     pub unpacked_size: UnpackedSize,
 }
 
-/// Alternatives for defining the unpacked size of the decoded data
+/// Alternatives for defining the unpacked size of the decoded data.
 #[derive(Clone, Copy, Debug)]
 pub enum UnpackedSize {
     /// Assume that the 8 bytes used to specify the unpacked size are present in the header.

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -1,3 +1,5 @@
+//! Encoding logic.
+
 pub mod dumbencoder;
 pub mod lzma2;
 pub mod options;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,20 @@
+//! Error handling.
+
 use std::io;
 use std::result;
 
+/// Library errors.
 #[derive(Debug)]
 pub enum Error {
+    /// I/O error.
     IOError(io::Error),
+    /// LZMA error.
     LZMAError(String),
+    /// XZ error.
     XZError(String),
 }
 
+/// Library result alias.
 pub type Result<T> = result::Result<T, Error>;
 
 impl From<io::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! Pure-Rust codecs for LZMA, LZMA2, and XZ.
+
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
 #![forbid(unsafe_code)]
 
 #[macro_use]
@@ -11,10 +15,12 @@ mod xz;
 use crate::decode::lzbuffer::LZBuffer;
 use std::io;
 
+/// Compression helpers.
 pub mod compress {
     pub use crate::encode::options::*;
 }
 
+/// Decompression helpers.
 pub mod decompress {
     pub use crate::decode::options::*;
 }
@@ -46,7 +52,7 @@ pub fn lzma_decompress_with_options<R: io::BufRead, W: io::Write>(
     Ok(())
 }
 
-/// Compresses the data with default [`Options`](compress/struct.Options.html).
+/// Compresses data with LZMA and default [`Options`](compress/struct.Options.html).
 pub fn lzma_compress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
@@ -54,6 +60,7 @@ pub fn lzma_compress<R: io::BufRead, W: io::Write>(
     lzma_compress_with_options(input, output, &compress::Options::default())
 }
 
+/// Compress LZMA data with the provided options.
 pub fn lzma_compress_with_options<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
@@ -63,6 +70,7 @@ pub fn lzma_compress_with_options<R: io::BufRead, W: io::Write>(
     encoder.process(input)
 }
 
+/// Decompress LZMA2 data with default [`Options`](decompress/struct.Options.html).
 pub fn lzma2_decompress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
@@ -70,6 +78,7 @@ pub fn lzma2_decompress<R: io::BufRead, W: io::Write>(
     decode::lzma2::decode_stream(input, output)
 }
 
+/// Compress data with LZMA2 and default [`Options`](compress/struct.Options.html).
 pub fn lzma2_compress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
@@ -77,6 +86,7 @@ pub fn lzma2_compress<R: io::BufRead, W: io::Write>(
     encode::lzma2::encode_stream(input, output)
 }
 
+/// Decompress XZ data with default [`Options`](decompress/struct.Options.html).
 pub fn xz_decompress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
@@ -84,6 +94,7 @@ pub fn xz_decompress<R: io::BufRead, W: io::Write>(
     decode::xz::decode_stream(input, output)
 }
 
+/// Compress data with XZ and default [`Options`](compress/struct.Options.html).
 pub fn xz_compress<R: io::BufRead, W: io::Write>(input: &mut R, output: &mut W) -> io::Result<()> {
     encode::xz::encode_stream(input, output)
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+/// Log trace message (feature: enabled).
 #[cfg(feature = "enable_logging")]
 #[macro_export]
 macro_rules! lzma_trace {
@@ -6,6 +7,7 @@ macro_rules! lzma_trace {
     }
 }
 
+/// Log debug message (feature: enabled).
 #[cfg(feature = "enable_logging")]
 #[macro_export]
 macro_rules! lzma_debug {
@@ -14,6 +16,7 @@ macro_rules! lzma_debug {
     }
 }
 
+/// Log info message (feature: enabled).
 #[cfg(feature = "enable_logging")]
 #[macro_export]
 macro_rules! lzma_info {
@@ -22,18 +25,21 @@ macro_rules! lzma_info {
     }
 }
 
+/// Log trace message (feature: disabled).
 #[cfg(not(feature = "enable_logging"))]
 #[macro_export]
 macro_rules! lzma_trace {
     ($($arg:tt)+) => {};
 }
 
+/// Log debug message (feature: disabled).
 #[cfg(not(feature = "enable_logging"))]
 #[macro_export]
 macro_rules! lzma_debug {
     ($($arg:tt)+) => {};
 }
 
+/// Log info message (feature: disabled).
 #[cfg(not(feature = "enable_logging"))]
 #[macro_export]
 macro_rules! lzma_info {

--- a/src/xz/mod.rs
+++ b/src/xz/mod.rs
@@ -4,9 +4,6 @@
 //!
 //! [spec]: https://tukaani.org/xz/xz-file-format.txt
 
-#![deny(missing_docs)]
-#![deny(missing_debug_implementations)]
-
 use crate::error;
 use std::io;
 


### PR DESCRIPTION
This adds all missing docstrings on public items, and enforces
linting on them.