### PR TITLE
Bump log version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 [dependencies]
 byteorder = "^1.0.0"
 crc = "^1.0.0"
-log = { version = "^0.4.0", optional = true }
-env_logger = { version = "^0.6.0", optional = true }
+log = { version = "^0.4.8", optional = true }
+env_logger = { version = "^0.7.1", optional = true }
 
 [features]
 enable_logging = ["env_logger", "log"]

--- a/benches/lzma.rs
+++ b/benches/lzma.rs
@@ -1,8 +1,5 @@
 #![feature(test)]
 
-#[cfg(feature = "enable_logging")]
-extern crate env_logger;
-extern crate lzma_rs;
 extern crate test;
 
 use std::io::Read;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,5 @@
 /// Log trace message (feature: enabled).
 #[cfg(feature = "enable_logging")]
-#[macro_export]
 macro_rules! lzma_trace {
     ($($arg:tt)+) => {
         log::trace!($($arg)+);
@@ -9,7 +8,6 @@ macro_rules! lzma_trace {
 
 /// Log debug message (feature: enabled).
 #[cfg(feature = "enable_logging")]
-#[macro_export]
 macro_rules! lzma_debug {
     ($($arg:tt)+) => {
         log::debug!($($arg)+);
@@ -18,7 +16,6 @@ macro_rules! lzma_debug {
 
 /// Log info message (feature: enabled).
 #[cfg(feature = "enable_logging")]
-#[macro_export]
 macro_rules! lzma_info {
     ($($arg:tt)+) => {
         log::info!($($arg)+);
@@ -27,21 +24,18 @@ macro_rules! lzma_info {
 
 /// Log trace message (feature: disabled).
 #[cfg(not(feature = "enable_logging"))]
-#[macro_export]
 macro_rules! lzma_trace {
     ($($arg:tt)+) => {};
 }
 
 /// Log debug message (feature: disabled).
 #[cfg(not(feature = "enable_logging"))]
-#[macro_export]
 macro_rules! lzma_debug {
     ($($arg:tt)+) => {};
 }
 
 /// Log info message (feature: disabled).
 #[cfg(not(feature = "enable_logging"))]
-#[macro_export]
 macro_rules! lzma_info {
     ($($arg:tt)+) => {};
 }

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -2,9 +2,6 @@
 extern crate env_logger;
 #[macro_use]
 extern crate lzma_rs;
-#[cfg(feature = "enable_logging")]
-#[macro_use]
-extern crate log;
 
 fn round_trip(x: &[u8]) {
     round_trip_no_options(x);

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "enable_logging")]
-extern crate env_logger;
-#[macro_use]
-extern crate lzma_rs;
+use log::{debug, info};
 
 fn round_trip(x: &[u8]) {
     round_trip_no_options(x);
@@ -19,8 +17,10 @@ fn round_trip(x: &[u8]) {
 fn round_trip_no_options(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();
     lzma_rs::lzma_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
-    lzma_info!("Compressed {} -> {} bytes", x.len(), compressed.len());
-    lzma_debug!("Compressed content: {:?}", compressed);
+    #[cfg(feature = "enable_logging")]
+    info!("Compressed {} -> {} bytes", x.len(), compressed.len());
+    #[cfg(feature = "enable_logging")]
+    debug!("Compressed content: {:?}", compressed);
     let mut bf = std::io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma_decompress(&mut bf, &mut decomp).unwrap();
@@ -39,8 +39,10 @@ fn round_trip_with_options(
         encode_options,
     )
     .unwrap();
-    lzma_info!("Compressed {} -> {} bytes", x.len(), compressed.len());
-    lzma_debug!("Compressed content: {:?}", compressed);
+    #[cfg(feature = "enable_logging")]
+    info!("Compressed {} -> {} bytes", x.len(), compressed.len());
+    #[cfg(feature = "enable_logging")]
+    debug!("Compressed content: {:?}", compressed);
     let mut bf = std::io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma_decompress_with_options(&mut bf, &mut decomp, decode_options).unwrap();

--- a/tests/lzma2.rs
+++ b/tests/lzma2.rs
@@ -2,9 +2,6 @@
 extern crate env_logger;
 #[macro_use]
 extern crate lzma_rs;
-#[cfg(feature = "enable_logging")]
-#[macro_use]
-extern crate log;
 
 fn round_trip(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();

--- a/tests/lzma2.rs
+++ b/tests/lzma2.rs
@@ -1,13 +1,13 @@
 #[cfg(feature = "enable_logging")]
-extern crate env_logger;
-#[macro_use]
-extern crate lzma_rs;
+use log::{debug, info};
 
 fn round_trip(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();
     lzma_rs::lzma2_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
-    lzma_info!("Compressed {} -> {} bytes", x.len(), compressed.len());
-    lzma_debug!("Compressed content: {:?}", compressed);
+    #[cfg(feature = "enable_logging")]
+    info!("Compressed {} -> {} bytes", x.len(), compressed.len());
+    #[cfg(feature = "enable_logging")]
+    debug!("Compressed content: {:?}", compressed);
     let mut bf = std::io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma2_decompress(&mut bf, &mut decomp).unwrap();

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -2,9 +2,6 @@
 extern crate env_logger;
 #[macro_use]
 extern crate lzma_rs;
-#[cfg(feature = "enable_logging")]
-#[macro_use]
-extern crate log;
 
 fn round_trip(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -1,13 +1,13 @@
 #[cfg(feature = "enable_logging")]
-extern crate env_logger;
-#[macro_use]
-extern crate lzma_rs;
+use log::{debug, info};
 
 fn round_trip(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();
     lzma_rs::xz_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
-    lzma_info!("Compressed {} -> {} bytes", x.len(), compressed.len());
-    lzma_debug!("Compressed content: {:?}", compressed);
+    #[cfg(feature = "enable_logging")]
+    info!("Compressed {} -> {} bytes", x.len(), compressed.len());
+    #[cfg(feature = "enable_logging")]
+    debug!("Compressed content: {:?}", compressed);
     let mut bf = std::io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::xz_decompress(&mut bf, &mut decomp).unwrap();


### PR DESCRIPTION
### Pull Request Overview

This pull request:
- Bumps the version of the log dependencies. The minimal versions were not working anymore since https://github.com/gendx/lzma-rs/pull/38.
- More `extern` statements are also removed.
- Macros are not exported anymore, [in line with the 2018 edition](https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html).


### Testing Strategy

This pull request was tested by Travis-CI, and running `cargo bench` manually.


### Supporting Documentation and References

N/A


### TODO or Help Wanted

N/A