### PR TITLE
Deny build warnings in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - cargo clippy --tests -- -D warnings -W clippy::match-same-arms
 
 script:
-  - cargo build --verbose
-  - cargo test  --verbose
-  - cargo build --verbose --all-features
-  - cargo test  --verbose --all-features
+  - RUSTFLAGS="-D warnings" cargo build --verbose
+  - RUSTFLAGS="-D warnings" cargo test  --verbose
+  - RUSTFLAGS="-D warnings" cargo build --verbose --all-features
+  - RUSTFLAGS="-D warnings" cargo test  --verbose --all-features


### PR DESCRIPTION
### Pull Request Overview

This pull request denies warning in Cargo build/test on Travis-CI.


### Testing Strategy

This pull request was tested by Travis-CI.


### Supporting Documentation and References

N/A


### TODO or Help Wanted

N/A