### PR TITLE
Implement Display for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! Error handling.
 
+use std::fmt::Display;
 use std::io;
 use std::result;
 
@@ -20,5 +21,40 @@ pub type Result<T> = result::Result<T, Error>;
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {
         Error::IOError(e)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::IOError(e) => write!(fmt, "io error: {}", e),
+            Error::LZMAError(e) => write!(fmt, "lzma error: {}", e),
+            Error::XZError(e) => write!(fmt, "xz error: {}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Error;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(
+            Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "this is an error"
+            ))
+            .to_string(),
+            "io error: this is an error"
+        );
+        assert_eq!(
+            Error::LZMAError("this is an error".to_string()).to_string(),
+            "lzma error: this is an error"
+        );
+        assert_eq!(
+            Error::XZError("this is an error".to_string()).to_string(),
+            "xz error: this is an error"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,15 @@ impl Display for Error {
     }
 }
 
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::IOError(e) => Some(e),
+            Error::LZMAError(_) | Error::XZError(_) => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::Error;


### PR DESCRIPTION
### Pull Request Overview

Useful for printing out error messages to users.

This is needed by future versions of #51 .

### Testing Strategy

This pull request was tested by...

- [x] Added relevant unit tests.
- [ ] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).

Already covered by existing test cases