### PR TITLE
lzma: fix clippy warnings

### DIFF
--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -24,12 +24,9 @@ impl LZMAParams {
         R: io::BufRead,
     {
         // Properties
-        let props = input.read_u8().or_else(|e| {
-            Err(error::Error::LZMAError(format!(
-                "LZMA header too short: {}",
-                e
-            )))
-        })?;
+        let props = input
+            .read_u8()
+            .map_err(|e| error::Error::LZMAError(format!("LZMA header too short: {}", e)))?;
 
         let mut pb = props as u32;
         if pb >= 225 {
@@ -47,12 +44,9 @@ impl LZMAParams {
         lzma_info!("Properties {{ lc: {}, lp: {}, pb: {} }}", lc, lp, pb);
 
         // Dictionary
-        let dict_size_provided = input.read_u32::<LittleEndian>().or_else(|e| {
-            Err(error::Error::LZMAError(format!(
-                "LZMA header too short: {}",
-                e
-            )))
-        })?;
+        let dict_size_provided = input
+            .read_u32::<LittleEndian>()
+            .map_err(|e| error::Error::LZMAError(format!("LZMA header too short: {}", e)))?;
         let dict_size = if dict_size_provided < 0x1000 {
             0x1000
         } else {
@@ -64,11 +58,8 @@ impl LZMAParams {
         // Unpacked size
         let unpacked_size: Option<u64> = match options.unpacked_size {
             UnpackedSize::ReadFromHeader => {
-                let unpacked_size_provided = input.read_u64::<LittleEndian>().or_else(|e| {
-                    Err(error::Error::LZMAError(format!(
-                        "LZMA header too short: {}",
-                        e
-                    )))
+                let unpacked_size_provided = input.read_u64::<LittleEndian>().map_err(|e| {
+                    error::Error::LZMAError(format!("LZMA header too short: {}", e))
                 })?;
                 let marker_mandatory: bool = unpacked_size_provided == 0xFFFF_FFFF_FFFF_FFFF;
                 if marker_mandatory {

--- a/src/decode/xz.rs
+++ b/src/decode/xz.rs
@@ -415,11 +415,11 @@ where
         }
 
         let mut buf = vec![0; size_of_properties as usize];
-        input.read_exact(buf.as_mut_slice()).or_else(|e| {
-            Err(error::Error::XZError(format!(
+        input.read_exact(buf.as_mut_slice()).map_err(|e| {
+            error::Error::XZError(format!(
                 "Could not read filter properties of size {}: {}",
                 size_of_properties, e
-            )))
+            ))
         })?;
 
         lzma_info!("XZ filter properties: {:?}", buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,8 @@ pub fn lzma_decompress_with_options<R: io::BufRead, W: io::Write>(
         decode::lzma::new_circular(output, params)?
     };
 
-    let mut rangecoder = decode::rangecoder::RangeDecoder::new(input).or_else(|e| {
-        Err(error::Error::LZMAError(format!(
-            "LZMA stream too short: {}",
-            e
-        )))
-    })?;
+    let mut rangecoder = decode::rangecoder::RangeDecoder::new(input)
+        .map_err(|e| error::Error::LZMAError(format!("LZMA stream too short: {}", e)))?;
     decoder.process(&mut rangecoder)?;
     decoder.output.finish()?;
     Ok(())


### PR DESCRIPTION
This fixes all linting warnings that were introduced on latest clippy.