### PR TITLE
Streaming Decompressor v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ env_logger = { version = "^0.7.1", optional = true }
 
 [features]
 enable_logging = ["env_logger", "log"]
+stream = []
 
 [badges]
 travis-ci = { repository = "gendx/lzma-rs", branch = "master" }

--- a/benches/lzma.rs
+++ b/benches/lzma.rs
@@ -34,11 +34,29 @@ fn decompress_bench(compressed: &[u8], b: &mut Bencher) {
     });
 }
 
+#[cfg(feature = "stream")]
+fn decompress_stream_bench(compressed: &[u8], b: &mut Bencher) {
+    use std::io::Write;
+    b.iter(|| {
+        let mut stream = lzma_rs::decompress::Stream::new(Vec::new());
+        stream.write_all(compressed).unwrap();
+        stream.finish().unwrap()
+    });
+}
+
 fn decompress_bench_file(compfile: &str, b: &mut Bencher) {
     let mut f = std::fs::File::open(compfile).unwrap();
     let mut compressed = Vec::new();
     f.read_to_end(&mut compressed).unwrap();
     decompress_bench(&compressed, b);
+}
+
+#[cfg(feature = "stream")]
+fn decompress_stream_bench_file(compfile: &str, b: &mut Bencher) {
+    let mut f = std::fs::File::open(compfile).unwrap();
+    let mut compressed = Vec::new();
+    f.read_to_end(&mut compressed).unwrap();
+    decompress_stream_bench(&compressed, b);
 }
 
 #[bench]
@@ -88,6 +106,14 @@ fn decompress_big_file(b: &mut Bencher) {
     #[cfg(feature = "enable_logging")]
     let _ = env_logger::try_init();
     decompress_bench_file("tests/files/foo.txt.lzma", b);
+}
+
+#[cfg(feature = "stream")]
+#[bench]
+fn decompress_stream_big_file(b: &mut Bencher) {
+    #[cfg(feature = "enable_logging")]
+    let _ = env_logger::try_init();
+    decompress_stream_bench_file("tests/files/foo.txt.lzma", b);
 }
 
 #[bench]

--- a/src/decode/lzbuffer.rs
+++ b/src/decode/lzbuffer.rs
@@ -18,8 +18,10 @@ where
     fn get_output(&self) -> &W;
     // Get a mutable reference to the output sink
     fn get_output_mut(&mut self) -> &mut W;
-    // Flush the buffer to the output
+    // Consumes this buffer and flushes any data
     fn finish(self) -> io::Result<W>;
+    // Consumes this buffer without flushing any data
+    fn into_output(self) -> W;
 }
 
 // An accumulating buffer for LZ sequences
@@ -143,11 +145,16 @@ where
         &mut self.stream
     }
 
-    // Flush the buffer to the output
+    // Consumes this buffer and flushes any data
     fn finish(mut self) -> io::Result<W> {
         self.stream.write_all(self.buf.as_slice())?;
         self.stream.flush()?;
         Ok(self.stream)
+    }
+
+    // Consumes this buffer without flushing any data
+    fn into_output(self) -> W {
+        self.stream
     }
 }
 
@@ -291,12 +298,17 @@ where
         &mut self.stream
     }
 
-    // Flush the buffer to the output
+    // Consumes this buffer and flushes any data
     fn finish(mut self) -> io::Result<W> {
         if self.cursor > 0 {
             self.stream.write_all(&self.buf[0..self.cursor])?;
             self.stream.flush()?;
         }
         Ok(self.stream)
+    }
+
+    // Consumes this buffer without flushing any data
+    fn into_output(self) -> W {
+        self.stream
     }
 }

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -7,3 +7,6 @@ pub mod options;
 pub mod rangecoder;
 pub mod util;
 pub mod xz;
+
+#[cfg(feature = "stream")]
+pub mod stream;

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -1,5 +1,5 @@
 /// Options to tweak decompression behavior.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be read from the header or provided.
     ///
@@ -10,10 +10,16 @@ pub struct Options {
     ///
     /// The default is unlimited.
     pub memlimit: Option<usize>,
+    /// Determines whether to bypass end of stream validation.
+    ///
+    /// This option only applies to the [`Stream`](struct.Stream.html) API.
+    ///
+    /// The default is false (always do completion check).
+    pub allow_incomplete: bool,
 }
 
 /// Alternatives for defining the unpacked size of the decoded data.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum UnpackedSize {
     /// Assume that the 8 bytes used to specify the unpacked size are present in the header.
     /// If the bytes are `0xFFFF_FFFF_FFFF_FFFF`, assume that there is an end-of-payload marker in
@@ -36,5 +42,21 @@ pub enum UnpackedSize {
 impl Default for UnpackedSize {
     fn default() -> UnpackedSize {
         UnpackedSize::ReadFromHeader
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_options() {
+        assert_eq!(
+            Options {
+                unpacked_size: UnpackedSize::ReadFromHeader,
+                memlimit: None,
+                allow_incomplete: false,
+            },
+            Options::default()
+        );
     }
 }

--- a/src/decode/rangecoder.rs
+++ b/src/decode/rangecoder.rs
@@ -7,9 +7,9 @@ pub struct RangeDecoder<'a, R>
 where
     R: 'a + io::BufRead,
 {
-    stream: &'a mut R,
-    range: u32,
-    code: u32,
+    pub stream: &'a mut R,
+    pub range: u32,
+    pub code: u32,
 }
 
 impl<'a, R> RangeDecoder<'a, R>
@@ -28,9 +28,31 @@ where
         Ok(dec)
     }
 
+    pub fn from_parts(stream: &'a mut R, range: u32, code: u32) -> Self {
+        Self {
+            stream,
+            range,
+            code,
+        }
+    }
+
+    pub fn set(&mut self, range: u32, code: u32) {
+        self.range = range;
+        self.code = code;
+    }
+
+    pub fn read_into(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        self.stream.read(dst)
+    }
+
     #[inline]
     pub fn is_finished_ok(&mut self) -> io::Result<bool> {
-        Ok(self.code == 0 && util::is_eof(self.stream)?)
+        Ok(self.code == 0 && self.is_eof()?)
+    }
+
+    #[inline]
+    pub fn is_eof(&mut self) -> io::Result<bool> {
+        util::is_eof(self.stream)
     }
 
     #[inline]
@@ -67,7 +89,7 @@ where
     }
 
     #[inline]
-    pub fn decode_bit(&mut self, prob: &mut u16) -> io::Result<bool> {
+    pub fn decode_bit(&mut self, prob: &mut u16, update: bool) -> io::Result<bool> {
         let bound: u32 = (self.range >> 11) * (*prob as u32);
 
         lzma_trace!(
@@ -77,13 +99,17 @@ where
             (self.code > bound) as u8
         );
         if self.code < bound {
-            *prob += (0x800_u16 - *prob) >> 5;
+            if update {
+                *prob += (0x800_u16 - *prob) >> 5;
+            }
             self.range = bound;
 
             self.normalize()?;
             Ok(false)
         } else {
-            *prob -= *prob >> 5;
+            if update {
+                *prob -= *prob >> 5;
+            }
             self.code -= bound;
             self.range -= bound;
 
@@ -92,10 +118,15 @@ where
         }
     }
 
-    fn parse_bit_tree(&mut self, num_bits: usize, probs: &mut [u16]) -> io::Result<u32> {
+    fn parse_bit_tree(
+        &mut self,
+        num_bits: usize,
+        probs: &mut [u16],
+        update: bool,
+    ) -> io::Result<u32> {
         let mut tmp: u32 = 1;
         for _ in 0..num_bits {
-            let bit = self.decode_bit(&mut probs[tmp as usize])?;
+            let bit = self.decode_bit(&mut probs[tmp as usize], update)?;
             tmp = (tmp << 1) ^ (bit as u32);
         }
         Ok(tmp - (1 << num_bits))
@@ -106,11 +137,12 @@ where
         num_bits: usize,
         probs: &mut [u16],
         offset: usize,
+        update: bool,
     ) -> io::Result<u32> {
         let mut result = 0u32;
         let mut tmp: usize = 1;
         for i in 0..num_bits {
-            let bit = self.decode_bit(&mut probs[offset + tmp])?;
+            let bit = self.decode_bit(&mut probs[offset + tmp], update)?;
             tmp = (tmp << 1) ^ (bit as usize);
             result ^= (bit as u32) << i;
         }
@@ -133,15 +165,20 @@ impl BitTree {
         }
     }
 
-    pub fn parse<R: io::BufRead>(&mut self, rangecoder: &mut RangeDecoder<R>) -> io::Result<u32> {
-        rangecoder.parse_bit_tree(self.num_bits, self.probs.as_mut_slice())
+    pub fn parse<R: io::BufRead>(
+        &mut self,
+        rangecoder: &mut RangeDecoder<R>,
+        update: bool,
+    ) -> io::Result<u32> {
+        rangecoder.parse_bit_tree(self.num_bits, self.probs.as_mut_slice(), update)
     }
 
     pub fn parse_reverse<R: io::BufRead>(
         &mut self,
         rangecoder: &mut RangeDecoder<R>,
+        update: bool,
     ) -> io::Result<u32> {
-        rangecoder.parse_reverse_bit_tree(self.num_bits, self.probs.as_mut_slice(), 0)
+        rangecoder.parse_reverse_bit_tree(self.num_bits, self.probs.as_mut_slice(), 0, update)
     }
 }
 
@@ -168,13 +205,14 @@ impl LenDecoder {
         &mut self,
         rangecoder: &mut RangeDecoder<R>,
         pos_state: usize,
+        update: bool,
     ) -> io::Result<usize> {
-        if !rangecoder.decode_bit(&mut self.choice)? {
-            Ok(self.low_coder[pos_state].parse(rangecoder)? as usize)
-        } else if !rangecoder.decode_bit(&mut self.choice2)? {
-            Ok(self.mid_coder[pos_state].parse(rangecoder)? as usize + 8)
+        if !rangecoder.decode_bit(&mut self.choice, update)? {
+            Ok(self.low_coder[pos_state].parse(rangecoder, update)? as usize)
+        } else if !rangecoder.decode_bit(&mut self.choice2, update)? {
+            Ok(self.mid_coder[pos_state].parse(rangecoder, update)? as usize + 8)
         } else {
-            Ok(self.high_coder.parse(rangecoder)? as usize + 16)
+            Ok(self.high_coder.parse(rangecoder, update)? as usize + 16)
         }
     }
 }

--- a/src/decode/stream.rs
+++ b/src/decode/stream.rs
@@ -1,0 +1,500 @@
+use crate::decode::lzbuffer::{LZBuffer, LZCircularBuffer};
+use crate::decode::lzma::{new_circular, new_circular_with_memlimit, DecoderState, LZMAParams};
+use crate::decode::rangecoder::RangeDecoder;
+use crate::decompress::Options;
+use crate::error::Error;
+use std::fmt::Debug;
+use std::io::{BufRead, Cursor, Read, Write};
+
+/// Minimum header length to be read.
+/// - props: u8 (1 byte)
+/// - dict_size: u32 (4 bytes)
+const MIN_HEADER_LEN: usize = 5;
+
+/// Max header length to be read.
+/// - unpacked_size: u64 (8 bytes)
+const MAX_HEADER_LEN: usize = MIN_HEADER_LEN + 8;
+
+/// Required bytes after the header.
+/// - ignore: u8 (1 byte)
+/// - code: u32 (4 bytes)
+const START_BYTES: usize = 5;
+
+/// Maximum number of bytes to buffer while reading the header.
+const MAX_TMP_LEN: usize = MAX_HEADER_LEN + START_BYTES;
+
+/// Internal state of this streaming decoder. This is needed because we have to
+/// initialize the stream before processing any data.
+#[derive(Debug)]
+enum State<W>
+where
+    W: Write,
+{
+    /// Stream is initialized but header values have not yet been read.
+    Header(W),
+    /// Header values have been read and the stream is ready to process more data.
+    Data(RunState<W>),
+}
+
+/// Structures needed while decoding data.
+struct RunState<W>
+where
+    W: Write,
+{
+    decoder: DecoderState<W, LZCircularBuffer<W>>,
+    range: u32,
+    code: u32,
+}
+
+impl<W> Debug for RunState<W>
+where
+    W: Write,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("RunState")
+            .field("range", &self.range)
+            .field("code", &self.code)
+            .finish()
+    }
+}
+
+/// Lzma decompressor that can process multiple chunks of data using the
+/// `std::io::Write` interface.
+pub struct Stream<W>
+where
+    W: Write,
+{
+    /// Temporary buffer to hold data while the header is being read.
+    tmp: Cursor<[u8; MAX_TMP_LEN]>,
+    /// Whether the stream is initialized and ready to process data.
+    /// An `Option` is used to avoid interior mutability when updating the state.
+    state: Option<State<W>>,
+    /// Options given when a stream is created.
+    options: Options,
+}
+
+impl<W> Stream<W>
+where
+    W: Write,
+{
+    /// Initialize the stream. This will consume the `output` which is the sink
+    /// implementing `std::io::Write` that will receive decompressed bytes.
+    pub fn new(output: W) -> Self {
+        Self::new_with_options(&Options::default(), output)
+    }
+
+    /// Initialize the stream with the given `options`. This will consume the
+    /// `output` which is the sink implementing `std::io::Write` that will
+    /// receive decompressed bytes.
+    pub fn new_with_options(options: &Options, output: W) -> Self {
+        Self {
+            tmp: Cursor::new([0; MAX_TMP_LEN]),
+            state: Some(State::Header(output)),
+            options: *options,
+        }
+    }
+
+    /// Get a reference to the output sink
+    pub fn get_output(&self) -> Option<&W> {
+        self.state.as_ref().map(|state| match state {
+            State::Header(output) => &output,
+            State::Data(state) => state.decoder.output.get_output(),
+        })
+    }
+
+    /// Get a mutable reference to the output sink
+    pub fn get_output_mut(&mut self) -> Option<&mut W> {
+        self.state.as_mut().map(|state| match state {
+            State::Header(output) => output,
+            State::Data(state) => state.decoder.output.get_output_mut(),
+        })
+    }
+
+    /// Consumes the stream and returns the output sink. This also makes sure
+    /// we have properly reached the end of the stream.
+    pub fn finish(mut self) -> crate::error::Result<W> {
+        if let Some(state) = self.state.take() {
+            match state {
+                State::Header(output) => {
+                    if self.tmp.position() > 0 {
+                        Err(Error::LZMAError("failed to read header".to_string()))
+                    } else {
+                        Ok(output)
+                    }
+                }
+                State::Data(mut state) => {
+                    if !self.options.allow_incomplete {
+                        // Process one last time with empty input to force end of
+                        // stream checks
+                        let mut stream =
+                            Cursor::new(&self.tmp.get_ref()[0..self.tmp.position() as usize]);
+                        let mut range_decoder =
+                            RangeDecoder::from_parts(&mut stream, state.range, state.code);
+                        state.decoder.process(&mut range_decoder)?;
+                    }
+                    let output = state.decoder.output.finish()?;
+                    Ok(output)
+                }
+            }
+        } else {
+            // this will occur if a call to `write()` fails
+            Err(Error::LZMAError(
+                "can't finish stream because of previous write error".to_string(),
+            ))
+        }
+    }
+
+    /// Attempts to read the header and transition into a running state.
+    ///
+    /// This function will consume the state, returning the next state on both
+    /// error and success.
+    fn read_header<R: BufRead>(
+        output: W,
+        mut input: &mut R,
+        options: &Options,
+    ) -> crate::error::Result<State<W>> {
+        match LZMAParams::read_header(&mut input, options) {
+            Ok(params) => {
+                let decoder = if let Some(memlimit) = options.memlimit {
+                    new_circular_with_memlimit(output, params, memlimit)
+                } else {
+                    new_circular(output, params)
+                }?;
+
+                // The RangeDecoder is only kept temporarily as we are processing
+                // chunks of data.
+                if let Ok(rangecoder) = RangeDecoder::new(&mut input) {
+                    Ok(State::Data(RunState {
+                        decoder,
+                        range: rangecoder.range,
+                        code: rangecoder.code,
+                    }))
+                } else {
+                    // Failed to create a RangeDecoder because we need more data,
+                    // try again later.
+                    Ok(State::Header(decoder.output.into_output()))
+                }
+            }
+            // Failed to read_header() because we need more data, try again later.
+            Err(Error::HeaderTooShort(_)) => Ok(State::Header(output)),
+            // Fatal error. Don't retry.
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Process compressed data
+    fn read_data<R: BufRead>(
+        mut state: RunState<W>,
+        mut input: &mut R,
+    ) -> std::io::Result<RunState<W>> {
+        // Construct our RangeDecoder from the previous range and code
+        // values.
+        let mut rangecoder = RangeDecoder::from_parts(&mut input, state.range, state.code);
+
+        // Try to process all bytes of data.
+        state
+            .decoder
+            .process_stream(&mut rangecoder)
+            .map_err(|e| -> std::io::Error { e.into() })?;
+
+        Ok(RunState {
+            decoder: state.decoder,
+            range: rangecoder.range,
+            code: rangecoder.code,
+        })
+    }
+}
+
+impl<W> Debug for Stream<W>
+where
+    W: Write + Debug,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("Stream")
+            .field("tmp", &self.tmp.position())
+            .field("state", &self.state)
+            .field("options", &self.options)
+            .finish()
+    }
+}
+
+impl<W> Write for Stream<W>
+where
+    W: Write,
+{
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        let mut input = Cursor::new(data);
+
+        if let Some(state) = self.state.take() {
+            let state = match state {
+                // Read the header values and transition into a running state.
+                State::Header(state) => {
+                    let res = if self.tmp.position() > 0 {
+                        // attempt to fill the tmp buffer
+                        let position = self.tmp.position();
+                        let bytes_read =
+                            input.read(&mut self.tmp.get_mut()[position as usize..])?;
+                        let bytes_read = if bytes_read < std::u64::MAX as usize {
+                            bytes_read as u64
+                        } else {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                "Failed to convert integer to u64.",
+                            ));
+                        };
+                        self.tmp.set_position(position + bytes_read);
+
+                        // attempt to read the header from our tmp buffer
+                        let (position, res) = {
+                            let mut tmp_input =
+                                Cursor::new(&self.tmp.get_ref()[0..self.tmp.position() as usize]);
+                            let res = Stream::read_header(state, &mut tmp_input, &self.options);
+                            (tmp_input.position(), res)
+                        };
+
+                        // discard all bytes up to position if reading the header
+                        // was successful
+                        if let Ok(State::Data(_)) = &res {
+                            let tmp = *self.tmp.get_ref();
+                            let end = self.tmp.position();
+                            let new_len = end - position;
+                            (&mut self.tmp.get_mut()[0..new_len as usize])
+                                .copy_from_slice(&tmp[position as usize..end as usize]);
+                            self.tmp.set_position(new_len);
+                        }
+                        res
+                    } else {
+                        Stream::read_header(state, &mut input, &self.options)
+                    };
+
+                    match res {
+                        // occurs when not enough input bytes were provided to
+                        // read the entire header
+                        Ok(State::Header(val)) => {
+                            if self.tmp.position() == 0 {
+                                // reset the cursor because we may have partial reads
+                                input.set_position(0);
+                                let bytes_read = input.read(&mut self.tmp.get_mut()[..])?;
+                                let bytes_read = if bytes_read < std::u64::MAX as usize {
+                                    bytes_read as u64
+                                } else {
+                                    return Err(std::io::Error::new(
+                                        std::io::ErrorKind::Other,
+                                        "Failed to convert integer to u64.",
+                                    ));
+                                };
+                                self.tmp.set_position(bytes_read);
+                            }
+                            State::Header(val)
+                        }
+
+                        // occurs when the header was successfully read and we
+                        // move on to the next state
+                        Ok(State::Data(val)) => State::Data(val),
+
+                        // occurs when the output was consumed due to a
+                        // non-recoverable error
+                        Err(e) => {
+                            return Err(match e {
+                                Error::IOError(e) | Error::HeaderTooShort(e) => e,
+                                Error::LZMAError(e) | Error::XZError(e) => {
+                                    std::io::Error::new(std::io::ErrorKind::Other, e)
+                                }
+                            });
+                        }
+                    }
+                }
+
+                // Process another chunk of data.
+                State::Data(state) => {
+                    let state = if self.tmp.position() > 0 {
+                        let mut tmp_input =
+                            Cursor::new(&self.tmp.get_ref()[0..self.tmp.position() as usize]);
+                        let res = Stream::read_data(state, &mut tmp_input)?;
+                        self.tmp.set_position(0);
+                        res
+                    } else {
+                        state
+                    };
+                    State::Data(Stream::read_data(state, &mut input)?)
+                }
+            };
+            self.state.replace(state);
+        }
+        Ok(input.position() as usize)
+    }
+
+    /// Flushes the output sink. The internal buffer isn't flushed to avoid
+    /// corrupting the internal state. Instead, call `finish()` to finalize the
+    /// stream and flush all remaining internal data.
+    fn flush(&mut self) -> std::io::Result<()> {
+        if let Some(ref mut state) = self.state {
+            match state {
+                State::Header(_) => Ok(()),
+                State::Data(state) => state.decoder.output.get_output_mut().flush(),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl std::convert::Into<std::io::Error> for Error {
+    fn into(self) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", self))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Test an empty stream
+    #[test]
+    fn test_stream_noop() {
+        let stream = Stream::new(Vec::new());
+        assert!(stream.get_output().unwrap().is_empty());
+
+        let output = stream.finish().unwrap();
+        assert!(output.is_empty());
+    }
+
+    /// Test writing an empty slice
+    #[test]
+    fn test_stream_zero() {
+        let mut stream = Stream::new(Vec::new());
+
+        stream.write_all(&[]).unwrap();
+        stream.write_all(&[]).unwrap();
+
+        let output = stream.finish().unwrap();
+
+        assert!(output.is_empty());
+    }
+
+    /// Test a bad header value
+    #[test]
+    #[should_panic(expected = "LZMA header invalid properties: 255 must be < 225")]
+    fn test_bad_header() {
+        let input = [255u8; 32];
+
+        let mut stream = Stream::new(Vec::new());
+
+        stream.write_all(&input[..]).unwrap();
+
+        let output = stream.finish().unwrap();
+
+        assert!(output.is_empty());
+    }
+
+    /// Test processing only partial data
+    #[test]
+    fn test_stream_incomplete() {
+        let input = b"\x5d\x00\x00\x80\x00\xff\xff\xff\xff\xff\xff\xff\xff\x00\x83\xff\
+                      \xfb\xff\xff\xc0\x00\x00\x00";
+        // Process until this index is reached.
+        let mut end = 1u64;
+
+        // Test when we fail to provide the minimum number of bytes required to
+        // read the header. Header size is 13 bytes but we also read the first 5
+        // bytes of data.
+        while end < (MAX_HEADER_LEN + START_BYTES) as u64 {
+            let mut stream = Stream::new(Vec::new());
+            stream.write_all(&input[..end as usize]).unwrap();
+            assert_eq!(stream.tmp.position(), end);
+
+            let err = stream.finish().unwrap_err();
+            assert!(
+                err.to_string().contains("failed to read header"),
+                "error was: {}",
+                err
+            );
+
+            end += 1;
+        }
+
+        // Test when we fail to provide enough bytes to terminate the stream. A
+        // properly terminated stream will have a code value of 0.
+        while end < input.len() as u64 {
+            let mut stream = Stream::new(Vec::new());
+            stream.write_all(&input[..end as usize]).unwrap();
+
+            // Header bytes will be buffered until there are enough to read
+            if end < (MAX_HEADER_LEN + START_BYTES) as u64 {
+                assert_eq!(stream.tmp.position(), end);
+            }
+
+            let err = stream.finish().unwrap_err();
+            assert!(err.to_string().contains("failed to fill whole buffer"));
+
+            end += 1;
+        }
+    }
+
+    /// Test processing all chunk sizes
+    #[test]
+    fn test_stream_chunked() {
+        let small_input = include_bytes!("../../tests/files/small.txt");
+
+        let mut reader = std::io::Cursor::new(&small_input[..]);
+        let mut small_input_compressed = Vec::new();
+        crate::lzma_compress(&mut reader, &mut small_input_compressed).unwrap();
+
+        let input : Vec<(&[u8], &[u8])> = vec![
+            (b"\x5d\x00\x00\x80\x00\xff\xff\xff\xff\xff\xff\xff\xff\x00\x83\xff\xfb\xff\xff\xc0\x00\x00\x00", b""),
+            (&small_input_compressed[..], small_input)];
+        for (input, expected) in input {
+            for chunk in 1..input.len() {
+                let mut consumed = 0;
+                let mut stream = Stream::new(Vec::new());
+                while consumed < input.len() {
+                    let end = std::cmp::min(consumed + chunk, input.len());
+                    stream.write_all(&input[consumed..end]).unwrap();
+                    consumed = end;
+                }
+                let output = stream.finish().unwrap();
+                assert_eq!(expected, &output[..]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_stream_corrupted() {
+        let mut stream = Stream::new(Vec::new());
+        let err = stream
+            .write_all(b"corrupted bytes here corrupted bytes here")
+            .unwrap_err();
+        assert!(err.to_string().contains("beyond output size"));
+        let err = stream.finish().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("can\'t finish stream because of previous write error"));
+    }
+
+    #[test]
+    fn test_allow_incomplete() {
+        let input = include_bytes!("../../tests/files/small.txt");
+
+        let mut reader = std::io::Cursor::new(&input[..]);
+        let mut compressed = Vec::new();
+        crate::lzma_compress(&mut reader, &mut compressed).unwrap();
+        let compressed = &compressed[..compressed.len() / 2];
+
+        // Should fail to finish() without the allow_incomplete option.
+        let mut stream = Stream::new(Vec::new());
+        stream.write_all(&compressed[..]).unwrap();
+        stream.finish().unwrap_err();
+
+        // Should succeed with the allow_incomplete option.
+        let mut stream = Stream::new_with_options(
+            &Options {
+                allow_incomplete: true,
+                ..Default::default()
+            },
+            Vec::new(),
+        );
+        stream.write_all(&compressed[..]).unwrap();
+        let output = stream.finish().unwrap();
+        assert_eq!(output, &input[..26]);
+    }
+}

--- a/src/encode/rangecoder.rs
+++ b/src/encode/rangecoder.rs
@@ -238,7 +238,7 @@ mod test {
         let mut decoder = RangeDecoder::new(&mut bufread).unwrap();
         let mut prob = prob_init;
         for &b in bits {
-            assert_eq!(decoder.decode_bit(&mut prob).unwrap(), b);
+            assert_eq!(decoder.decode_bit(&mut prob, true).unwrap(), b);
         }
         assert!(decoder.is_finished_ok().unwrap());
     }
@@ -267,7 +267,7 @@ mod test {
         let mut decoder = RangeDecoder::new(&mut bufread).unwrap();
         let mut tree = decode::rangecoder::BitTree::new(num_bits);
         for &v in values {
-            assert_eq!(tree.parse(&mut decoder).unwrap(), v);
+            assert_eq!(tree.parse(&mut decoder, true).unwrap(), v);
         }
         assert!(decoder.is_finished_ok().unwrap());
     }
@@ -309,7 +309,7 @@ mod test {
         let mut decoder = RangeDecoder::new(&mut bufread).unwrap();
         let mut tree = decode::rangecoder::BitTree::new(num_bits);
         for &v in values {
-            assert_eq!(tree.parse_reverse(&mut decoder).unwrap(), v);
+            assert_eq!(tree.parse_reverse(&mut decoder, true).unwrap(), v);
         }
         assert!(decoder.is_finished_ok().unwrap());
     }
@@ -352,7 +352,7 @@ mod test {
         let mut len_decoder = LenDecoder::new();
         for &v in values {
             assert_eq!(
-                len_decoder.decode(&mut decoder, pos_state).unwrap(),
+                len_decoder.decode(&mut decoder, pos_state, true).unwrap(),
                 v as usize
             );
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ use std::result;
 pub enum Error {
     /// I/O error.
     IOError(io::Error),
+    /// Not enough bytes to complete header
+    HeaderTooShort(io::Error),
     /// LZMA error.
     LZMAError(String),
     /// XZ error.
@@ -28,6 +30,7 @@ impl Display for Error {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::IOError(e) => write!(fmt, "io error: {}", e),
+            Error::HeaderTooShort(e) => write!(fmt, "header too short: {}", e),
             Error::LZMAError(e) => write!(fmt, "lzma error: {}", e),
             Error::XZError(e) => write!(fmt, "xz error: {}", e),
         }
@@ -37,7 +40,7 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::IOError(e) => Some(e),
+            Error::IOError(e) | Error::HeaderTooShort(e) => Some(e),
             Error::LZMAError(_) | Error::XZError(_) => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub mod compress {
 /// Decompression helpers.
 pub mod decompress {
     pub use crate::decode::options::*;
+    #[cfg(feature = "stream")]
+    pub use crate::decode::stream::Stream;
 }
 
 /// Decompress LZMA data with default [`Options`](decompress/struct.Options.html).

--- a/tests/files/small.txt
+++ b/tests/files/small.txt
@@ -1,0 +1,1 @@
+Project Gutenberg's Alice's Adventures in Wonderland, by Lewis Carroll


### PR DESCRIPTION
### Pull Request Overview

Changes since last PR:
* removed YODA-style if-statements to improve readability
* removed do-while style logic to make a more readable `loop`
* removed confusing `RangeDecoder::remaining` function
* removed unnecessary clippy lint
* removed range checking when casting to `u64`
* renamed `Mode` to `ProcessingMode` and added a `ProcessingStatus` instead of using a `bool`
* renamed `tmp` to `partial_input_buf` to make it more clear
* fixed indentation on multi-line byte strings
* made `RangeDecoder` members public instead of having getters
* added more documentation to why `unpacked_size_write_none_to_header_and_use_provided_on_read` causes a `WriteZero` error
* added a test utility function for reading a file into a `Vec<u8>`
* added comment as to why `MAX_REQUIRED_INPUT` is 20 bytes
* added a utility function to `read_partial_input_buf`


### Testing Strategy

This pull request was tested by...

- [x] Added relevant unit tests.
- [x] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).


### Supporting Documentation and References
 Link to previous PR: #58 
