### PR TITLE
Bump minimum supported version to Rust 1.34.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.32.0  # pinned minimum supported toolchain
+  - 1.34.0  # pinned minimum supported toolchain
 
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Update minimum supported Rust version: 1.32.0 -> 1.34.0
+
 ## 0.1.3
 
 - Minimum supported Rust version: 1.32.0.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/lzma-rs/badge.svg)](https://docs.rs/lzma-rs)
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![Build Status](https://travis-ci.org/gendx/lzma-rs.svg?branch=master)](https://travis-ci.org/gendx/lzma-rs)
-[![Minimum rust 1.32](https://img.shields.io/badge/rust-1.32%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1320-2019-01-17)
+[![Minimum rust 1.34](https://img.shields.io/badge/rust-1.34%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1340-2019-04-11)
 
 This project is a decoder for LZMA and its variants written in pure Rust, with focus on clarity.
 It already supports LZMA, LZMA2 and a subset of the `.xz` file format.


### PR DESCRIPTION
### Pull Request Overview

This pull request bumps the minimum supported version from Rust 1.32.0 to 1.34.0. As evidenced by https://travis-ci.org/github/gendx/lzma-rs/builds/747669302, some of the fuzzing dependencies relies on [str::split_ascii_whitespace](https://doc.rust-lang.org/std/primitive.str.html#method.split_ascii_whitespace), which was stabilized in version 1.34.0, on 2019-04-11.


### Testing Strategy

This pull request was tested by Travis-CI.


### Supporting Documentation and References

See https://doc.rust-lang.org/std/primitive.str.html#method.split_ascii_whitespace.

### TODO or Help Wanted

N/A