### PR TITLE
Detach lifetime of output buffer from DecoderState

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.40.0  # MSRV
+          - 1.50.0  # MSRV
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/lzma-rs/badge.svg)](https://docs.rs/lzma-rs)
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 ![Build Status](https://github.com/gendx/lzma-rs/workflows/Build%20and%20run%20tests/badge.svg)
-[![Minimum rust 1.40](https://img.shields.io/badge/rust-1.40%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1400-2019-12-19)
+[![Minimum rust 1.50](https://img.shields.io/badge/rust-1.50%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11)
 
 This project is a decoder for LZMA and its variants written in pure Rust, with focus on clarity.
 It already supports LZMA, LZMA2 and a subset of the `.xz` file format.

--- a/src/decode/lzbuffer.rs
+++ b/src/decode/lzbuffer.rs
@@ -39,11 +39,7 @@ impl<W> LzAccumBuffer<W>
 where
     W: io::Write,
 {
-    pub fn from_stream(stream: W) -> Self {
-        Self::from_stream_with_memlimit(stream, std::usize::MAX)
-    }
-
-    pub fn from_stream_with_memlimit(stream: W, memlimit: usize) -> Self {
+    pub fn from_stream(stream: W, memlimit: usize) -> Self {
         Self {
             stream,
             buf: Vec::new(),
@@ -175,7 +171,7 @@ impl<W> LzCircularBuffer<W>
 where
     W: io::Write,
 {
-    pub fn from_stream_with_memlimit(stream: W, dict_size: usize, memlimit: usize) -> Self {
+    pub fn from_stream(stream: W, dict_size: usize, memlimit: usize) -> Self {
         lzma_info!("Dict size in LZ buffer: {}", dict_size);
         Self {
             stream,

--- a/src/decode/rangecoder.rs
+++ b/src/decode/rangecoder.rs
@@ -180,6 +180,10 @@ impl BitTree {
     ) -> io::Result<u32> {
         rangecoder.parse_reverse_bit_tree(self.num_bits, self.probs.as_mut_slice(), 0, update)
     }
+
+    pub fn reset(&mut self) {
+        self.probs.fill(0x400);
+    }
 }
 
 pub struct LenDecoder {
@@ -214,5 +218,13 @@ impl LenDecoder {
         } else {
             Ok(self.high_coder.parse(rangecoder, update)? as usize + 16)
         }
+    }
+
+    pub fn reset(&mut self) {
+        self.choice = 0x400;
+        self.choice2 = 0x400;
+        self.low_coder.iter_mut().for_each(|t| t.reset());
+        self.mid_coder.iter_mut().for_each(|t| t.reset());
+        self.high_coder.reset();
     }
 }


### PR DESCRIPTION
### Pull Request Overview
This pull request introduces **no new APIs** and makes no modifications to existing ones. There are no new features added. It is prep work for future features as per https://github.com/gendx/lzma-rs/issues/72.

This PR does two things.

* Removes ownership of `output` from `DecoderState`.
  * This removes the restriction of `DecoderState` to be parameterized on the lifetime of the output buffer to enable more flexible usage.
* Reuses already allocated buffers where possible for a small performance increase and additional flexibility for `DecoderState`
  * No public APIs have changed. Observable behaviour should be identical for existing consumers.


### Testing Strategy

This pull request was tested by...

- [x] The existing test suite is sufficient and should all pass. There should be no observable changes in behaviour or public API.

