### PR TITLE
Expose API for raw decoder primitives for LZMA and LZMA2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ raw_decoder = []
 
 [package.metadata.docs.rs]
 features = ["stream", "raw_decoder"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust-lzma = "0.5"
 [features]
 enable_logging = ["env_logger", "log"]
 stream = []
+raw_decoder = []
 
 [package.metadata.docs.rs]
-features = ["stream"]
+features = ["stream", "raw_decoder"]

--- a/src/decode/lzma2.rs
+++ b/src/decode/lzma2.rs
@@ -1,6 +1,6 @@
 use crate::decode::lzbuffer;
 use crate::decode::lzbuffer::LzBuffer;
-use crate::decode::lzma;
+use crate::decode::lzma::DecoderState;
 use crate::decode::lzma::LzmaProperties;
 use crate::decode::rangecoder;
 use crate::error;
@@ -8,188 +8,216 @@ use byteorder::{BigEndian, ReadBytesExt};
 use std::io;
 use std::io::Read;
 
-pub fn decode_stream<R, W>(input: &mut R, output: &mut W) -> error::Result<()>
-where
-    R: io::BufRead,
-    W: io::Write,
-{
-    let mut accum = lzbuffer::LzAccumBuffer::from_stream(output, usize::MAX);
-    let mut decoder = lzma::DecoderState::new(
-        LzmaProperties {
+#[derive(Debug)]
+/// Raw decoder for LZMA2.
+pub struct Lzma2Decoder {
+    lzma_state: DecoderState,
+}
+
+impl Lzma2Decoder {
+    /// Creates a new object ready for decompressing data that it's given.
+    pub fn new() -> Lzma2Decoder {
+        Lzma2Decoder {
+            lzma_state: DecoderState::new(
+                LzmaProperties {
+                    lc: 0,
+                    lp: 0,
+                    pb: 0,
+                },
+                None,
+            ),
+        }
+    }
+
+    /// Performs the equivalent of replacing this decompression state with a freshly allocated copy.
+    ///
+    /// This function may not allocate memory and will attempt to reuse any previously allocated resources.
+    #[cfg(feature = "raw_decoder")]
+    pub fn reset(&mut self) {
+        self.lzma_state.reset_state(LzmaProperties {
             lc: 0,
             lp: 0,
             pb: 0,
-        },
-        None,
-    );
-
-    loop {
-        let status = input
-            .read_u8()
-            .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected new status: {}", e)))?;
-
-        lzma_info!("LZMA2 status: {}", status);
-
-        if status == 0 {
-            lzma_info!("LZMA2 end of input");
-            break;
-        } else if status == 1 {
-            // uncompressed reset dict
-            parse_uncompressed(&mut accum, input, true)?;
-        } else if status == 2 {
-            // uncompressed no reset
-            parse_uncompressed(&mut accum, input, false)?;
-        } else {
-            parse_lzma(&mut accum, &mut decoder, input, status)?;
-        }
+        });
     }
 
-    accum.finish()?;
-    Ok(())
-}
+    /// Decompresses the input data into the output, consuming only as much input as needed and writing as much output as possible.
+    pub fn decompress<W: io::Write, R: io::BufRead>(
+        &mut self,
+        input: &mut R,
+        output: &mut W,
+    ) -> error::Result<()> {
+        let mut accum = lzbuffer::LzAccumBuffer::from_stream(output, usize::MAX);
 
-fn parse_lzma<R, W>(
-    accum: &mut lzbuffer::LzAccumBuffer<W>,
-    decoder: &mut lzma::DecoderState,
-    input: &mut R,
-    status: u8,
-) -> error::Result<()>
-where
-    R: io::BufRead,
-    W: io::Write,
-{
-    if status & 0x80 == 0 {
-        return Err(error::Error::LzmaError(format!(
-            "LZMA2 invalid status {}, must be 0, 1, 2 or >= 128",
-            status
-        )));
-    }
-
-    let reset_dict: bool;
-    let reset_state: bool;
-    let reset_props: bool;
-    match (status >> 5) & 0x3 {
-        0 => {
-            reset_dict = false;
-            reset_state = false;
-            reset_props = false;
-        }
-        1 => {
-            reset_dict = false;
-            reset_state = true;
-            reset_props = false;
-        }
-        2 => {
-            reset_dict = false;
-            reset_state = true;
-            reset_props = true;
-        }
-        3 => {
-            reset_dict = true;
-            reset_state = true;
-            reset_props = true;
-        }
-        _ => unreachable!(),
-    }
-
-    let unpacked_size = input
-        .read_u16::<BigEndian>()
-        .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected unpacked size: {}", e)))?;
-    let unpacked_size = ((((status & 0x1F) as u64) << 16) | (unpacked_size as u64)) + 1;
-
-    let packed_size = input
-        .read_u16::<BigEndian>()
-        .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected packed size: {}", e)))?;
-    let packed_size = (packed_size as u64) + 1;
-
-    lzma_info!(
-        "LZMA2 compressed block {{ unpacked_size: {}, packed_size: {}, reset_dict: {}, reset_state: {}, reset_props: {} }}",
-        unpacked_size,
-        packed_size,
-        reset_dict,
-        reset_state,
-        reset_props
-    );
-
-    if reset_dict {
-        accum.reset()?;
-    }
-
-    if reset_state {
-        let new_props = if reset_props {
-            let props = input.read_u8().map_err(|e| {
-                error::Error::LzmaError(format!("LZMA2 expected new properties: {}", e))
+        loop {
+            let status = input.read_u8().map_err(|e| {
+                error::Error::LzmaError(format!("LZMA2 expected new status: {}", e))
             })?;
 
-            let mut pb = props as u32;
-            if pb >= 225 {
-                return Err(error::Error::LzmaError(format!(
-                    "LZMA2 invalid properties: {} must be < 225",
-                    pb
-                )));
+            lzma_info!("LZMA2 status: {}", status);
+
+            if status == 0 {
+                lzma_info!("LZMA2 end of input");
+                break;
+            } else if status == 1 {
+                // uncompressed reset dict
+                Self::parse_uncompressed(&mut accum, input, true)?;
+            } else if status == 2 {
+                // uncompressed no reset
+                Self::parse_uncompressed(&mut accum, input, false)?;
+            } else {
+                self.parse_lzma(&mut accum, input, status)?;
             }
+        }
 
-            let lc = pb % 9;
-            pb /= 9;
-            let lp = pb % 5;
-            pb /= 5;
-
-            if lc + lp > 4 {
-                return Err(error::Error::LzmaError(format!(
-                    "LZMA2 invalid properties: lc + lp ({} + {}) must be <= 4",
-                    lc, lp
-                )));
-            }
-
-            lzma_info!("Properties {{ lc: {}, lp: {}, pb: {} }}", lc, lp, pb);
-            LzmaProperties { lc, lp, pb }
-        } else {
-            decoder.lzma_props
-        };
-
-        decoder.reset_state(new_props);
+        accum.finish()?;
+        Ok(())
     }
 
-    decoder.set_unpacked_size(Some(unpacked_size + accum.len() as u64));
+    fn parse_lzma<R, W>(
+        &mut self,
+        accum: &mut lzbuffer::LzAccumBuffer<W>,
+        input: &mut R,
+        status: u8,
+    ) -> error::Result<()>
+    where
+        R: io::BufRead,
+        W: io::Write,
+    {
+        if status & 0x80 == 0 {
+            return Err(error::Error::LzmaError(format!(
+                "LZMA2 invalid status {}, must be 0, 1, 2 or >= 128",
+                status
+            )));
+        }
 
-    let mut taken = input.take(packed_size);
-    let mut rangecoder = rangecoder::RangeDecoder::new(&mut taken)
-        .map_err(|e| error::Error::LzmaError(format!("LZMA input too short: {}", e)))?;
-    decoder.process(accum, &mut rangecoder)
-}
+        let reset_dict: bool;
+        let reset_state: bool;
+        let reset_props: bool;
+        match (status >> 5) & 0x3 {
+            0 => {
+                reset_dict = false;
+                reset_state = false;
+                reset_props = false;
+            }
+            1 => {
+                reset_dict = false;
+                reset_state = true;
+                reset_props = false;
+            }
+            2 => {
+                reset_dict = false;
+                reset_state = true;
+                reset_props = true;
+            }
+            3 => {
+                reset_dict = true;
+                reset_state = true;
+                reset_props = true;
+            }
+            _ => unreachable!(),
+        }
 
-fn parse_uncompressed<R, W>(
-    accum: &mut lzbuffer::LzAccumBuffer<W>,
-    input: &mut R,
-    reset_dict: bool,
-) -> error::Result<()>
-where
-    R: io::BufRead,
-    W: io::Write,
-{
-    let unpacked_size = input
-        .read_u16::<BigEndian>()
-        .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected unpacked size: {}", e)))?;
-    let unpacked_size = (unpacked_size as usize) + 1;
+        let unpacked_size = input
+            .read_u16::<BigEndian>()
+            .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected unpacked size: {}", e)))?;
+        let unpacked_size = ((((status & 0x1F) as u64) << 16) | (unpacked_size as u64)) + 1;
 
-    lzma_info!(
-        "LZMA2 uncompressed block {{ unpacked_size: {}, reset_dict: {} }}",
-        unpacked_size,
-        reset_dict
-    );
+        let packed_size = input
+            .read_u16::<BigEndian>()
+            .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected packed size: {}", e)))?;
+        let packed_size = (packed_size as u64) + 1;
 
-    if reset_dict {
-        accum.reset()?;
+        lzma_info!(
+            "LZMA2 compressed block {{ unpacked_size: {}, packed_size: {}, reset_dict: {}, reset_state: {}, reset_props: {} }}",
+            unpacked_size,
+            packed_size,
+            reset_dict,
+            reset_state,
+            reset_props
+        );
+
+        if reset_dict {
+            accum.reset()?;
+        }
+
+        if reset_state {
+            let new_props = if reset_props {
+                let props = input.read_u8().map_err(|e| {
+                    error::Error::LzmaError(format!("LZMA2 expected new properties: {}", e))
+                })?;
+
+                let mut pb = props as u32;
+                if pb >= 225 {
+                    return Err(error::Error::LzmaError(format!(
+                        "LZMA2 invalid properties: {} must be < 225",
+                        pb
+                    )));
+                }
+
+                let lc = pb % 9;
+                pb /= 9;
+                let lp = pb % 5;
+                pb /= 5;
+
+                if lc + lp > 4 {
+                    return Err(error::Error::LzmaError(format!(
+                        "LZMA2 invalid properties: lc + lp ({} + {}) must be <= 4",
+                        lc, lp
+                    )));
+                }
+
+                lzma_info!("Properties {{ lc: {}, lp: {}, pb: {} }}", lc, lp, pb);
+                LzmaProperties { lc, lp, pb }
+            } else {
+                self.lzma_state.lzma_props
+            };
+
+            self.lzma_state.reset_state(new_props);
+        }
+
+        self.lzma_state
+            .set_unpacked_size(Some(unpacked_size + accum.len() as u64));
+
+        let mut taken = input.take(packed_size);
+        let mut rangecoder = rangecoder::RangeDecoder::new(&mut taken)
+            .map_err(|e| error::Error::LzmaError(format!("LZMA input too short: {}", e)))?;
+        self.lzma_state.process(accum, &mut rangecoder)
     }
 
-    let mut buf = vec![0; unpacked_size];
-    input.read_exact(buf.as_mut_slice()).map_err(|e| {
-        error::Error::LzmaError(format!(
-            "LZMA2 expected {} uncompressed bytes: {}",
-            unpacked_size, e
-        ))
-    })?;
-    accum.append_bytes(buf.as_slice());
+    fn parse_uncompressed<R, W>(
+        accum: &mut lzbuffer::LzAccumBuffer<W>,
+        input: &mut R,
+        reset_dict: bool,
+    ) -> error::Result<()>
+    where
+        R: io::BufRead,
+        W: io::Write,
+    {
+        let unpacked_size = input
+            .read_u16::<BigEndian>()
+            .map_err(|e| error::Error::LzmaError(format!("LZMA2 expected unpacked size: {}", e)))?;
+        let unpacked_size = (unpacked_size as usize) + 1;
 
-    Ok(())
+        lzma_info!(
+            "LZMA2 uncompressed block {{ unpacked_size: {}, reset_dict: {} }}",
+            unpacked_size,
+            reset_dict
+        );
+
+        if reset_dict {
+            accum.reset()?;
+        }
+
+        let mut buf = vec![0; unpacked_size];
+        input.read_exact(buf.as_mut_slice()).map_err(|e| {
+            error::Error::LzmaError(format!(
+                "LZMA2 expected {} uncompressed bytes: {}",
+                unpacked_size, e
+            ))
+        })?;
+        accum.append_bytes(buf.as_slice());
+
+        Ok(())
+    }
 }

--- a/src/decode/rangecoder.rs
+++ b/src/decode/rangecoder.rs
@@ -151,7 +151,7 @@ where
 }
 
 // TODO: parametrize by constant and use [u16; 1 << num_bits] as soon as Rust supports this
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct BitTree {
     num_bits: usize,
     probs: Vec<u16>,
@@ -186,6 +186,7 @@ impl BitTree {
     }
 }
 
+#[derive(Debug)]
 pub struct LenDecoder {
     choice: u16,
     choice2: u16,

--- a/src/decode/stream.rs
+++ b/src/decode/stream.rs
@@ -61,6 +61,7 @@ where
 
 /// Lzma decompressor that can process multiple chunks of data using the
 /// `io::Write` interface.
+#[cfg_attr(docsrs, doc(cfg(stream)))]
 pub struct Stream<W>
 where
     W: Write,

--- a/src/decode/xz.rs
+++ b/src/decode/xz.rs
@@ -1,6 +1,6 @@
 //! Decoder for the `.xz` file format.
 
-use crate::decode::lzma2;
+use crate::decode::lzma2::Lzma2Decoder;
 use crate::decode::util;
 use crate::error;
 use crate::xz::{footer, header, CheckMethod, StreamFlags};
@@ -352,7 +352,7 @@ where
                 )));
             }
             // TODO: properties??
-            lzma2::decode_stream(&mut count_input, output)?;
+            Lzma2Decoder::new().decompress(&mut count_input, output)?;
             Ok(count_input.count())
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Pure-Rust codecs for LZMA, LZMA2, and XZ.
-
+#![cfg_attr(docsrs, feature(doc_cfg, doc_cfg_hide))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![forbid(unsafe_code)]
@@ -24,13 +24,17 @@ pub mod compress {
 /// Decompression helpers.
 pub mod decompress {
     pub use crate::decode::options::*;
+
     #[cfg(feature = "raw_decoder")]
+    #[cfg_attr(docsrs, doc(cfg(raw_decoder)))]
     pub mod raw {
         //! Raw decoding primitives for LZMA/LZMA2 streams.
         pub use crate::decode::lzma::{LzmaDecoder, LzmaParams, LzmaProperties};
         pub use crate::decode::lzma2::Lzma2Decoder;
     }
+
     #[cfg(feature = "stream")]
+    #[cfg_attr(docsrs, doc(cfg(stream)))]
     pub use crate::decode::stream::Stream;
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #72 by refactoring decoder functions to expose a zero-cost raw decoder API. The existing public API has been refactored to use the raw decoder API internally. The following additions to the public API become available with the `raw_decoder` feature enabled under the `decompress::raw` module.

* `LzmaDecoder`
  * `LzmaDecoder::new(params: LzmaParams, memlimit: Option<usize>) -> Result<Self>`
  * `LzmaDecoder::reset(&mut self, unpacked_size: Option<Option<u64>>)`
  * `LzmaDecoder::decompress<'a, W: io::Write, R: io::BufRead>(&mut self, input: &mut R, output: &'a mut W)`
* `Lzma2Decoder`
  * `Lzma2Decoder::new() -> Self`
  * `Lzma2Decoder::reset(&mut self)`
  * `Lzma2Decoder::decompress<'a, W: io::Write, R: io::BufRead>(&mut self, input: &mut R, output: &'a mut W)`
* `LzmaProperties`
* `LzmaParams`
  * `LzmaParams::new(properties: LzmaProperties, dict_size: u32, unpacked_size: Option<u64>) -> Self`
  * `LzmaParams:read_header<R>(input: &mut R, options: &Options) -> error::Result<LzmaParams>`
     * This was a previously internal API that is now exposed only when `raw_decoder` is enabled. I don't see any reason to restrict this to internal usage.

Additionally, annotations have been added to indicate availability of APIs on docs.rs.
![image](https://user-images.githubusercontent.com/1000503/172910167-2c4fc466-138f-4002-a6c2-f3bcb022970c.png)

### Testing Strategy
- [x] The existing test suite is sufficient and should all pass. The existing API tests have been refactored to use the `raw_decoder` APIs internally.