### PR TITLE
Allow passing in a preallocated buffer to LzBuffer constructors

### DIFF
--- a/src/decode/stream.rs
+++ b/src/decode/stream.rs
@@ -136,7 +136,7 @@ where
                             .decoder
                             .process(&mut state.output, &mut range_decoder)?;
                     }
-                    let output = state.output.finish()?;
+                    let (output, _) = state.output.finish()?;
                     Ok(output)
                 }
             }
@@ -164,6 +164,7 @@ where
                     output,
                     params.dict_size as usize,
                     options.memlimit.unwrap_or(usize::MAX),
+                    Vec::new(),
                 );
                 // The RangeDecoder is only kept temporarily as we are processing
                 // chunks of data.


### PR DESCRIPTION
### Pull Request Overview
This is a small experiment building off of the raw primitives introduced in #74 to design a solution for #27.

This PR introduces the functions `LzmaDecoder::new_with_buffer` and `Lzma2Decoder::new_with_buffer` that allow constructing an LZMA(2) decoder with a preallocated `Vec<u8>` buffer. The buffer is then reused on subsequent calls to `decompress`. `Lzma(2)Decoder::reset` will clear (`memset`) the buffer without dropping the prior allocation although it may be resized if necessary within internal decompression routines.

This allows consumers to pre-allocate a buffer upfront to mitigate the performance impact seen after #22 if necessary when using the raw decoder API.

I'm not actually sure this gives any performance benefit but I'm just putting it out here to get some thoughts. 

### Help Wanted

This pull request still needs proper benchmarking in a variety of cases. For my own usage in https://github.com/SnowflakePowered/chd-rs, I saw absolutely no performance difference between preallocating a buffer or using a fresh one via `Vec::new()`. There was also no difference in performance for my use case gained by reusing the buffer on each `decompress`. 

### Testing Strategy

This pull request was tested by...

- [ ] Added relevant unit tests.
- [ ] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).