### PR TITLE
Update dependencies (particularly crc 3.0.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ exclude = ["tests/*", "benches/*", "fuzz/*", ".github/*", "Cargo.lock"]
 edition = "2018"
 
 [dependencies]
-byteorder = "^1.0.0"
-crc = "^1.0.0"
-log = { version = "^0.4.14", optional = true }
-env_logger = { version = "^0.8.3", optional = true }
+byteorder = "1.4.3"
+crc = "3.0.0"
+log = { version = "0.4.17", optional = true }
+env_logger = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 rust-lzma = "0.5"

--- a/src/xz/crc.rs
+++ b/src/xz/crc.rs
@@ -1,0 +1,4 @@
+use crc::{Crc, CRC_32_ISO_HDLC, CRC_64_XZ};
+
+pub const CRC32: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
+pub const CRC64: Crc<u64> = Crc::<u64>::new(&CRC_64_XZ);

--- a/src/xz/mod.rs
+++ b/src/xz/mod.rs
@@ -7,6 +7,7 @@
 use crate::error;
 use std::io;
 
+pub(crate) mod crc;
 pub(crate) mod footer;
 pub(crate) mod header;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...

- Updates `byteorder` to `1.4.3`
- Updates `log` to `0.4.17`
- Updates `env_logger` to `0.9.0`
- Updates `crc` to `3.0.0`
  - `crc` from `^1.0.0` -> `3.0.0` represents a very large API change. In particular, algorithms are now const-initialized and `Digest` no longer implements `Hash`, so `Write/Read` for `DigestWrite/Read` (formerly `HasherWrite/Read`) has to be implemented per type. This results in most of the code changes in this PR. 
  - The particular selection of CRC polynomials are consistent with the old version of `crc` and the XZ specification. See [CRC-64/XZ](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-64-xz) and and [CRC-32/ISO-HDLC](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iso-hdlc) in the catalogue of parameterised CRC algorithms.

### Testing Strategy

This pull request was tested by ...
- [x] The existing tests are sufficient and should all pass