### PR TITLE
Use const generics to remove BitTree heap allocations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.50.0  # MSRV
+          - 1.57.0  # MSRV
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ env_logger = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 rust-lzma = "0.5"
+seq-macro = "0.3"
 
 [features]
 enable_logging = ["env_logger", "log"]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![Documentation](https://docs.rs/lzma-rs/badge.svg)](https://docs.rs/lzma-rs)
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 ![Build Status](https://github.com/gendx/lzma-rs/workflows/Build%20and%20run%20tests/badge.svg)
-[![Minimum rust 1.50](https://img.shields.io/badge/rust-1.50%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11)
-[![Codecov](https://codecov.io/gh/gendx/lzma-rs/branch/master/graph/badge.svg?token=HVo74E0wzh)](https://codecov.io/gh/gendx/lzma-rs)
+[![Minimum rust 1.57](https://img.shields.io/badge/rust-1.57%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25)
 
 This project is a decoder for LZMA and its variants written in pure Rust, with focus on clarity.
 It already supports LZMA, LZMA2 and a subset of the `.xz` file format.

--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -167,8 +167,8 @@ pub(crate) struct DecoderState {
     pub(crate) lzma_props: LzmaProperties,
     unpacked_size: Option<u64>,
     literal_probs: Vec2D<u16>,
-    pos_slot_decoder: [BitTree; 4],
-    align_decoder: BitTree,
+    pos_slot_decoder: [BitTree<{ 1 << 6 }>; 4],
+    align_decoder: BitTree<{ 1 << 4 }>,
     pos_decoders: [u16; 115],
     is_match: [u16; 192], // true = LZ, false = literal
     is_rep: [u16; 12],
@@ -191,12 +191,12 @@ impl DecoderState {
             unpacked_size,
             literal_probs: Vec2D::init(0x400, (1 << (lzma_props.lc + lzma_props.lp), 0x300)),
             pos_slot_decoder: [
-                BitTree::new(6),
-                BitTree::new(6),
-                BitTree::new(6),
-                BitTree::new(6),
+                BitTree::new(),
+                BitTree::new(),
+                BitTree::new(),
+                BitTree::new(),
             ],
-            align_decoder: BitTree::new(4),
+            align_decoder: BitTree::new(),
             pos_decoders: [0x400; 115],
             is_match: [0x400; 192],
             is_rep: [0x400; 12],
@@ -222,11 +222,16 @@ impl DecoderState {
         }
 
         self.lzma_props = new_props;
-        self.pos_slot_decoder.iter_mut().for_each(|t| t.reset());
-        self.align_decoder.reset();
         // For stack-allocated arrays, it was found to be faster to re-create new arrays
         // dropping the existing one, rather than using `fill` to reset the contents to zero.
         // Heap-based arrays use fill to keep their allocation rather than reallocate.
+        self.pos_slot_decoder = [
+            BitTree::new(),
+            BitTree::new(),
+            BitTree::new(),
+            BitTree::new(),
+        ];
+        self.align_decoder = BitTree::new();
         self.pos_decoders = [0x400; 115];
         self.is_match = [0x400; 192];
         self.is_rep = [0x400; 12];
@@ -236,8 +241,8 @@ impl DecoderState {
         self.is_rep_0long = [0x400; 192];
         self.state = 0;
         self.rep = [0; 4];
-        self.len_decoder.reset();
-        self.rep_len_decoder.reset();
+        self.len_decoder = LenDecoder::new();
+        self.rep_len_decoder = LenDecoder::new();
     }
 
     pub fn set_unpacked_size(&mut self, unpacked_size: Option<u64>) {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,18 @@
 pub mod vec2d;
+
+/// macro for compile-time const assertions
+macro_rules! const_assert {
+    ($message:expr, $($list:ident : $ty:ty),* => $expr:expr) => {{
+        struct Assert<$(const $list: $ty,)*>;
+        impl<$(const $list: $ty,)*> Assert<$($list,)*> {
+            const OK: () = {
+                if !($expr) {
+                    ::std::panic!(::std::concat!("assertion failed: ", $message));
+                }
+            };
+        }
+        Assert::<$($list,)*>::OK
+    }};
+}
+
+pub(crate) use const_assert;


### PR DESCRIPTION
### Pull Request Overview

#19 was blocked on `#[feature(generic_const_exprs)]` for the `1 << NUM_BITS` issue but we do not actually need `generic_const_exprs` to utilize const generics at the expense of having a slightly surprising API for `BitTree`. Since `BitTree` is an internal implementation detail, I do not think it is too much of a trade-off for the performance benefits seen. The strong compile time guarantee of the validity of `BitTree` when using `NUM_BITS` in an expression can be replicated with a compile time assert in the constructor.

~~There are **2 different API shapes** for `BitTree` proposed here. Both APIs validate their const arguments at compile time, and invalid instances of `BitTree` are still unconstructable.~~

~~1. `BitTree<const NUM_BITS: usize, const PROBS_ARRAY_LEN: usize>` (06aee699384477e09aa98e3d029197e927536b31)~~
2. `BitTree<const PROBS_ARRAY_LEN: usize>` (260eefe24b47e07d8cff2ccc8afda36755ce5ca2)

The first signature must have the caller input both `NUM_BITS`, and `PROBS_ARRAY_LEN == 1 << NUM_BITS` as part of the type signature. The equality of `PROBS_ARRAY_LEN` is checked by a compile-time assert macro that simply checks that indeed `PROBS_ARRAY_LEN == 1 << NUM_BITS`. This prevents the construction of a `BitTree` where `PROBS_ARRAY_LEN` is not `1 << NUM_BITS`

The second signature takes only `PROBS_ARRAY_LEN` to sidestep the requirement for `generic_const_exprs`. Instead, `NUM_BITS` is an associated constant that is calculated as `floor(log_2(PROBS_ARRAY_LEN))` using `PROBS_ARRAY_LEN.trailing_zeros()` which has been `const` since Rust 1.32. The const assert instead checks that `PROBS_ARRAY_LEN == 1 << (PROBS_ARRAY_LEN.trailing_zeros())`. Thus, rather than `BitTree` being valid for any `NUM_BITS` and `PROBS_ARRAY_LEN == 1 << NUM_BITS`, `BitTree` in this API is valid for any `PROBS_ARRAY_LEN` such that `PROBS_ARRAY_LEN == 2 ** floor(log_2(PROBS_ARRAY_LEN))`, which gives us effectively the same guarantees as the first signature without the redundant `NUM_BITS` argument. 

Both signatures compile to the same code and have the same performance. It is a matter of preference and readability on which to take. I have a slight preference for the second signature because it is less noisy and seeing `BitTree<{1 << 8}>` for example seems fairly obvious, but purely looking at the implementation, I prefer the less 'clever' first signature.

This PR bumps the MSRV to 1.57 for const generics and const_panic.

#### Benchmarks

In general, variances are reduced and there is a speed bump when accessing the dictionary during decompression. While I did apply const-generics to `encode::rangecoder::BitTree` for consistency, they don't seem to be currently used for compression so compression benchmarks should not be heavily affected if at all. 

Without const generics
```
running 8 tests
test compress_65536                  ... bench:   1,312,743 ns/iter (+/- 45,836)
test compress_empty                  ... bench:         712 ns/iter (+/- 55)
test compress_hello                  ... bench:       1,022 ns/iter (+/- 18)
test decompress_after_compress_65536 ... bench:   1,157,757 ns/iter (+/- 64,077)
test decompress_after_compress_empty ... bench:       1,897 ns/iter (+/- 82)
test decompress_after_compress_hello ... bench:       2,256 ns/iter (+/- 165)
test decompress_big_file             ... bench:   3,615,488 ns/iter (+/- 128,563)
test decompress_huge_dict            ... bench:       2,318 ns/iter (+/- 135)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out; finished in 16.21s
```

With const generic BitTree
```
test compress_65536                  ... bench:   1,317,185 ns/iter (+/- 58,197)
test compress_empty                  ... bench:         791 ns/iter (+/- 65)
test compress_hello                  ... bench:       1,108 ns/iter (+/- 45)
test decompress_after_compress_65536 ... bench:   1,189,749 ns/iter (+/- 60,014)
test decompress_after_compress_empty ... bench:         530 ns/iter (+/- 23)
test decompress_after_compress_hello ... bench:         787 ns/iter (+/- 26)
test decompress_big_file             ... bench:   3,600,336 ns/iter (+/- 375,302)
test decompress_huge_dict            ... bench:         873 ns/iter (+/- 33)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out; finished in 11.17s
```

This should fix #19, after this PR, `DecoderState` only has the single heap allocation of `literal_probs` which is substantially more difficult to put on the stack. 

### Testing Strategy
* This is a backend change and does not introduce additional functionality, existing tests should pass.
