### PR TITLE
Migrate GitHub actions to dtolnay/rust-toolchain.

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -7,10 +7,6 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Build benches
         run: cargo build --benches --verbose

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+name: Formatting on stable toolchain
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Check formatting on fuzzing
+        run: cargo fmt --manifest-path fuzz/Cargo.toml -- --check

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -7,11 +7,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo fuzz
         run: cargo install cargo-fuzz
       - name: Build fuzz targets

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,43 +1,19 @@
 on: [push, pull_request]
 name: Lints on stable toolchain
 jobs:
-  lints:
+  clippy:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
-
-      - name: Check formatting on fuzzing
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path fuzz/Cargo.toml -- --check
+          components: clippy
 
       - name: Check Clippy lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings -W clippy::match-same-arms
-
+        run: cargo clippy -- -W clippy::match-same-arms
       - name: Check Clippy lints on tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --tests -- -D warnings -W clippy::match-same-arms
-
+        run: cargo clippy --tests -- -W clippy::match-same-arms
       - name: Check Clippy lints on fuzzing
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path fuzz/Cargo.toml -- -D warnings -W clippy::match-same-arms
+        run: cargo clippy --manifest-path fuzz/Cargo.toml -- -W clippy::match-same-arms

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,28 +18,15 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
+
       - name: Build with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Tests with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
       - name: Build with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-features --verbose
+        run: cargo build --all-features --verbose
       - name: Tests with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --verbose
+        run: cargo test --all-features --verbose


### PR DESCRIPTION
### Pull Request Overview

This pull request migrates workflows to https://github.com/dtolnay/rust-toolchain.

Also separate formatting away from Clippy lints, into its own `format.yml`.


### Testing Strategy

This pull request was tested by...

- [x] Running GitHub actions.


### Supporting Documentation and References

- https://www.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/
- https://github.com/actions-rs/toolchain/issues/216


### TODO or Help Wanted

N/A