### PR TITLE
Configure formatting style to `imports_granularity = "Module"`.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,11 +1,11 @@
 on: [push, pull_request]
-name: Formatting on stable toolchain
+name: Formatting on nightly toolchain
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Module"

--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -1,8 +1,7 @@
 use crate::decode::lzbuffer::{LzBuffer, LzCircularBuffer};
 use crate::decode::rangecoder;
 use crate::decode::rangecoder::RangeDecoder;
-use crate::decompress::Options;
-use crate::decompress::UnpackedSize;
+use crate::decompress::{Options, UnpackedSize};
 use crate::error;
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::io;

--- a/src/decode/lzma2.rs
+++ b/src/decode/lzma2.rs
@@ -1,8 +1,6 @@
-use crate::decode::lzbuffer;
 use crate::decode::lzbuffer::LzBuffer;
-use crate::decode::lzma::DecoderState;
-use crate::decode::lzma::LzmaProperties;
-use crate::decode::rangecoder;
+use crate::decode::lzma::{DecoderState, LzmaProperties};
+use crate::decode::{lzbuffer, rangecoder};
 use crate::error;
 use byteorder::{BigEndian, ReadBytesExt};
 use std::io;

--- a/src/decode/util.rs
+++ b/src/decode/util.rs
@@ -1,5 +1,4 @@
-use std::hash;
-use std::io;
+use std::{hash, io};
 
 pub fn read_tag<R: io::BufRead>(input: &mut R, tag: &[u8]) -> io::Result<bool> {
     let mut buf = vec![0; tag.len()];

--- a/src/encode/util.rs
+++ b/src/encode/util.rs
@@ -1,5 +1,4 @@
-use std::hash;
-use std::io;
+use std::{hash, io};
 
 // A Write computing a digest on the bytes written.
 pub struct HasherWrite<'a, W, H>

--- a/src/encode/xz.rs
+++ b/src/encode/xz.rs
@@ -1,6 +1,5 @@
 use crate::decode;
-use crate::encode::lzma2;
-use crate::encode::util;
+use crate::encode::{lzma2, util};
 use crate::xz::{footer, header, CheckMethod, StreamFlags};
 use byteorder::{LittleEndian, WriteBytesExt};
 use crc::{crc32, Hasher32};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
 //! Error handling.
 
 use std::fmt::Display;
-use std::io;
-use std::result;
+use std::{io, result};
 
 /// Library errors.
 #[derive(Debug)]


### PR DESCRIPTION
### Pull Request Overview

This pull request specifies the formatting style for imports which was implicit until now.


### Testing Strategy

This pull request was tested by...

- [x] Running the `format` GitHub Workflow.


### Supporting Documentation and References

[Rustfmt docs for `imports_granularity`](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#imports_granularity).


### TODO or Help Wanted

N/A