### PR TITLE
Add coverage report action with grcov & Codecov.

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,2 @@
+output-type: lcov
+output-file: ./lcov.info

--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,2 +1,6 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+filter: covered
 output-type: lcov
 output-file: ./lcov.info

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
       - name: Code coverage for tests with default features
-        run: cargo test --verbose
+        run: cargo test --all-features --workspace --verbose
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+name: Code coverage
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Code coverage for tests with default features
+        run: cargo test --verbose
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+      - name: rust-grcov
+        uses: actions-rs/grcov@v0.1.5
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          verbose: true
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 ![Build Status](https://github.com/gendx/lzma-rs/workflows/Build%20and%20run%20tests/badge.svg)
 [![Minimum rust 1.50](https://img.shields.io/badge/rust-1.50%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11)
+[![Codecov](https://codecov.io/gh/gendx/lzma-rs/branch/master/graph/badge.svg?token=HVo74E0wzh)](https://codecov.io/gh/gendx/lzma-rs)
 
 This project is a decoder for LZMA and its variants written in pure Rust, with focus on clarity.
 It already supports LZMA, LZMA2 and a subset of the `.xz` file format.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds code coverage report using grcov, uploaded to Codecov.

Fixes #84.


### Testing Strategy

This pull request was tested by checking whether the GitHub Action works.


### Supporting Documentation and References

- https://github.com/codecov/example-rust
- https://github.com/actions-rs/grcov


### TODO or Help Wanted

From what I can tell, functions with generic parameters are missed from code coverage (https://app.codecov.io/gh/gendx/lzma-rs/blob/coverage/src/decode/lzma2.rs), e.g.

```rust
impl Lzma2Decoder {
    pub fn decompress<W: io::Write, R: io::BufRead>(
        &mut self,
        input: &mut R,
        output: &mut W,
    ) -> error::Result<()> {
        ...
    }
}
```

This issue doesn't seem to apply to generic parameters coming from a `struct` (https://app.codecov.io/gh/gendx/lzma-rs/blob/coverage/src/decode/rangecoder.rs), e.g.

```rust

impl<'a, R> RangeDecoder<'a, R>
where
    R: io::BufRead,
{
    pub fn new(stream: &'a mut R) -> io::Result<Self> {
        ...
    }
}
```