### PR TITLE
Add coverage report action with cargo-llvm-cov & Codecov.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Code coverage
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          files: lcov.info
+          verbose: true
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 ![Build Status](https://github.com/gendx/lzma-rs/workflows/Build%20and%20run%20tests/badge.svg)
 [![Minimum rust 1.50](https://img.shields.io/badge/rust-1.50%2B-orange.svg)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11)
+[![Codecov](https://codecov.io/gh/gendx/lzma-rs/branch/master/graph/badge.svg?token=HVo74E0wzh)](https://codecov.io/gh/gendx/lzma-rs)
 
 This project is a decoder for LZMA and its variants written in pure Rust, with focus on clarity.
 It already supports LZMA, LZMA2 and a subset of the `.xz` file format.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds code coverage report using cargo-llvm-cov, uploaded to Codecov.

Fixes https://github.com/gendx/lzma-rs/issues/84.


### Testing Strategy

This pull request was tested by checking whether the GitHub Action works.


### Supporting Documentation and References

- https://github.com/codecov/example-rust
- https://lib.rs/crates/cargo-llvm-cov


### TODO or Help Wanted

N/A