### PR TITLE
Split Codecov report into unit and integration tests.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: Code coverage
 jobs:
-  coverage:
+  unit_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -9,10 +9,27 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lib --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3.1.0
         with:
           files: lcov.info
+          flags: unit
+          verbose: true
+          fail_ci_if_error: true
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --test '*' --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          files: lcov.info
+          flags: integration
           verbose: true
           fail_ci_if_error: true


### PR DESCRIPTION
### Pull Request Overview

This pull request adds Codecov flags to separate coverage coming from unit tests vs. integration tests.


### Testing Strategy

This pull request was tested by running the GitHub workflows.


### Supporting Documentation and References

- https://docs.codecov.com/docs/flags
- https://github.com/codecov/codecov-action
- https://github.com/rust-lang/cargo/issues/8396


### TODO or Help Wanted

N/A