### PR TITLE
allow user to ignore trailing bytes

### DIFF
--- a/src/decode/lzma2.rs
+++ b/src/decode/lzma2.rs
@@ -14,7 +14,7 @@ pub struct Lzma2Decoder {
 
 impl Lzma2Decoder {
     /// Creates a new object ready for decompressing data that it's given.
-    pub fn new() -> Lzma2Decoder {
+    pub fn new(decoder_options: crate::decompress::Options) -> Lzma2Decoder {
         Lzma2Decoder {
             lzma_state: DecoderState::new(
                 LzmaProperties {
@@ -22,6 +22,7 @@ impl Lzma2Decoder {
                     lp: 0,
                     pb: 0,
                 },
+                decoder_options,
                 None,
             ),
         }

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -16,6 +16,10 @@ pub struct Options {
     ///
     /// The default is false (always do completion check).
     pub allow_incomplete: bool,
+
+    /// Determines whether to allow for any bytes remaining in the buffer after "end-of-stream" marker
+    /// The default is false (always do completion check).
+    pub allow_trailing_bytes: bool,
 }
 
 /// Alternatives for defining the unpacked size of the decoded data.
@@ -55,6 +59,7 @@ mod test {
                 unpacked_size: UnpackedSize::ReadFromHeader,
                 memlimit: None,
                 allow_incomplete: false,
+                allow_trailing_bytes: false,
             },
             Options::default()
         );

--- a/src/decode/stream.rs
+++ b/src/decode/stream.rs
@@ -159,7 +159,8 @@ where
     ) -> crate::error::Result<State<W>> {
         match LzmaParams::read_header(&mut input, options) {
             Ok(params) => {
-                let decoder = DecoderState::new(params.properties, params.unpacked_size);
+                let decoder =
+                    DecoderState::new(params.properties, options.clone(), params.unpacked_size);
                 let output = LzCircularBuffer::from_stream(
                     output,
                     params.dict_size as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ mod xz;
 
 use std::io;
 
+use decompress::Options;
+
 /// Compression helpers.
 pub mod compress {
     pub use crate::encode::options::*;
@@ -54,7 +56,7 @@ pub fn lzma_decompress_with_options<R: io::BufRead, W: io::Write>(
     options: &decompress::Options,
 ) -> error::Result<()> {
     let params = decode::lzma::LzmaParams::read_header(input, options)?;
-    let mut decoder = decode::lzma::LzmaDecoder::new(params, options.memlimit)?;
+    let mut decoder = decode::lzma::LzmaDecoder::new(params, options.memlimit, options.clone())?;
     decoder.decompress(input, output)
 }
 
@@ -80,8 +82,9 @@ pub fn lzma_compress_with_options<R: io::BufRead, W: io::Write>(
 pub fn lzma2_decompress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
+    decoder_options: decompress::Options,
 ) -> error::Result<()> {
-    decode::lzma2::Lzma2Decoder::new().decompress(input, output)
+    decode::lzma2::Lzma2Decoder::new(decoder_options).decompress(input, output)
 }
 
 /// Compress data with LZMA2 and default [`Options`](compress/struct.Options.html).
@@ -96,8 +99,9 @@ pub fn lzma2_compress<R: io::BufRead, W: io::Write>(
 pub fn xz_decompress<R: io::BufRead, W: io::Write>(
     input: &mut R,
     output: &mut W,
+    decoder_options: Options,
 ) -> error::Result<()> {
-    decode::xz::decode_stream(input, output)
+    decode::xz::decode_stream(input, output, decoder_options)
 }
 
 /// Compress data with XZ and default [`Options`](compress/struct.Options.html).

--- a/tests/lzma2.rs
+++ b/tests/lzma2.rs
@@ -9,7 +9,7 @@ fn read_all_file(filename: &str) -> std::io::Result<Vec<u8>> {
     Ok(data)
 }
 
-fn round_trip(x: &[u8]) {
+fn round_trip(x: &[u8], decoder_options: lzma_rs::decompress::Options) {
     let mut compressed: Vec<u8> = Vec::new();
     lzma_rs::lzma2_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
     #[cfg(feature = "enable_logging")]
@@ -18,35 +18,38 @@ fn round_trip(x: &[u8]) {
     debug!("Compressed content: {:?}", compressed);
     let mut bf = std::io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
-    lzma_rs::lzma2_decompress(&mut bf, &mut decomp).unwrap();
+    lzma_rs::lzma2_decompress(&mut bf, &mut decomp, decoder_options).unwrap();
     assert_eq!(decomp, x)
 }
 
-fn round_trip_file(filename: &str) {
+fn round_trip_file(filename: &str, decoder_options: lzma_rs::decompress::Options) {
     let x = read_all_file(filename).unwrap();
-    round_trip(x.as_slice());
+    round_trip(x.as_slice(), decoder_options);
 }
 
 #[test]
 fn round_trip_basics() {
+    let options = lzma_rs::decompress::Options::default();
     #[cfg(feature = "enable_logging")]
     let _ = env_logger::try_init();
-    round_trip(b"");
+    round_trip(b"", options.clone());
     // Note: we use vec! to avoid storing the slice in the binary
-    round_trip(vec![0x00; 1_000_000].as_slice());
-    round_trip(vec![0xFF; 1_000_000].as_slice());
+    round_trip(vec![0x00; 1_000_000].as_slice(), options.clone());
+    round_trip(vec![0xFF; 1_000_000].as_slice(), options.clone());
 }
 
 #[test]
 fn round_trip_hello() {
+    let options = Default::default();
     #[cfg(feature = "enable_logging")]
     let _ = env_logger::try_init();
-    round_trip(b"Hello world");
+    round_trip(b"Hello world", options);
 }
 
 #[test]
 fn round_trip_files() {
+    let options = Default::default();
     #[cfg(feature = "enable_logging")]
     let _ = env_logger::try_init();
-    round_trip_file("tests/files/foo.txt");
+    round_trip_file("tests/files/foo.txt", options);
 }


### PR DESCRIPTION
### Pull Request Overview
it allows for user to ignore trailing bytes, which made the crate unusable for me personally

### Testing Strategy

This pull request was tested by...

- [ ] Added relevant unit tests.
- [ ] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).

