### PR TITLE
lib: enable no-std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = "1.4.3"
 crc = "3.0.0"
 log = { version = "0.4.17", optional = true }
 env_logger = { version = "0.9.0", optional = true }
+core2 = { version = "^0.4", optional = true }
 
 [dev-dependencies]
 rust-lzma = "0.5"
@@ -25,6 +26,7 @@ seq-macro = "0.3"
 enable_logging = ["env_logger", "log"]
 stream = []
 raw_decoder = []
+no_std = ["core2"]
 
 [package.metadata.docs.rs]
 features = ["stream", "raw_decoder"]

--- a/src/decode/lzbuffer.rs
+++ b/src/decode/lzbuffer.rs
@@ -1,4 +1,7 @@
 use crate::error;
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 pub trait LzBuffer<W>

--- a/src/decode/lzma2.rs
+++ b/src/decode/lzma2.rs
@@ -3,8 +3,10 @@ use crate::decode::lzma::{DecoderState, LzmaProperties};
 use crate::decode::{lzbuffer, rangecoder};
 use crate::error;
 use byteorder::{BigEndian, ReadBytesExt};
-use std::io;
-use std::io::Read;
+#[cfg(feature = "no_std")]
+use core2::io::{self, Read};
+#[cfg(not(feature = "no_std"))]
+use std::io::{self, Read};
 
 #[derive(Debug)]
 /// Raw decoder for LZMA2.

--- a/src/decode/rangecoder.rs
+++ b/src/decode/rangecoder.rs
@@ -2,6 +2,9 @@ use crate::decode::util;
 use crate::error;
 use crate::util::const_assert;
 use byteorder::{BigEndian, ReadBytesExt};
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 pub struct RangeDecoder<'a, R>

--- a/src/decode/util.rs
+++ b/src/decode/util.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 pub fn read_tag<R: io::BufRead>(input: &mut R, tag: &[u8]) -> io::Result<bool> {

--- a/src/decode/xz.rs
+++ b/src/decode/xz.rs
@@ -5,9 +5,13 @@ use crate::decode::util;
 use crate::error;
 use crate::xz::crc::{CRC32, CRC64};
 use crate::xz::{footer, header, CheckMethod, StreamFlags};
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
-use std::io;
-use std::io::Read;
+#[cfg(feature = "no_std")]
+use core2::io::{self, Read};
+#[cfg(not(feature = "no_std"))]
+use std::io::{self, Read};
 
 #[derive(Debug)]
 struct Record {

--- a/src/encode/dumbencoder.rs
+++ b/src/encode/dumbencoder.rs
@@ -1,6 +1,9 @@
 use crate::compress::{Options, UnpackedSize};
 use crate::encode::rangecoder;
 use byteorder::{LittleEndian, WriteBytesExt};
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 pub struct Encoder<'a, W>

--- a/src/encode/lzma2.rs
+++ b/src/encode/lzma2.rs
@@ -1,4 +1,9 @@
+#[cfg(feature = "no_std")]
+use alloc::vec;
 use byteorder::{BigEndian, WriteBytesExt};
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 pub fn encode_stream<R, W>(input: &mut R, output: &mut W) -> io::Result<()>

--- a/src/encode/rangecoder.rs
+++ b/src/encode/rangecoder.rs
@@ -1,4 +1,9 @@
+#[cfg(all(test, feature = "no_std"))]
+use alloc::vec::Vec;
 use byteorder::WriteBytesExt;
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 #[cfg(test)]

--- a/src/encode/util.rs
+++ b/src/encode/util.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 /// An [`io::Write`] computing a digest on the bytes written.

--- a/src/encode/xz.rs
+++ b/src/encode/xz.rs
@@ -3,8 +3,10 @@ use crate::encode::{lzma2, util};
 use crate::xz::crc::CRC32;
 use crate::xz::{footer, header, CheckMethod, StreamFlags};
 use byteorder::{LittleEndian, WriteBytesExt};
-use std::io;
-use std::io::Write;
+#[cfg(feature = "no_std")]
+use core2::io::{self, Write};
+#[cfg(not(feature = "no_std"))]
+use std::io::{self, Write};
 
 pub fn encode_stream<R, W>(input: &mut R, output: &mut W) -> io::Result<()>
 where

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,17 @@
 //! Error handling.
 
-use std::fmt::Display;
-use std::{io, result};
+#[cfg(feature = "no_std")]
+use alloc::string::String;
+#[cfg(feature = "no_std")]
+use core::fmt::{self, Display};
+#[cfg(feature = "no_std")]
+use core::result;
+#[cfg(feature = "no_std")]
+use core2::{error, io};
+#[cfg(not(feature = "no_std"))]
+use std::fmt::{self, Display};
+#[cfg(not(feature = "no_std"))]
+use std::{error, io, result};
 
 /// Library errors.
 #[derive(Debug)]
@@ -26,7 +36,7 @@ impl From<io::Error> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::IoError(e) => write!(fmt, "io error: {}", e),
             Error::HeaderTooShort(e) => write!(fmt, "header too short: {}", e),
@@ -36,8 +46,8 @@ impl Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Error::IoError(e) | Error::HeaderTooShort(e) => Some(e),
             Error::LzmaError(_) | Error::XzError(_) => None,
@@ -48,15 +58,15 @@ impl std::error::Error for Error {
 #[cfg(test)]
 mod test {
     use super::Error;
+    #[cfg(feature = "no_std")]
+    use core2::io;
+    #[cfg(not(feature = "no_std"))]
+    use std::io;
 
     #[test]
     fn test_display() {
         assert_eq!(
-            Error::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "this is an error"
-            ))
-            .to_string(),
+            Error::IoError(io::Error::new(io::ErrorKind::Other, "this is an error")).to_string(),
             "io error: this is an error"
         );
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 //! Pure-Rust codecs for LZMA, LZMA2, and XZ.
 #![cfg_attr(docsrs, feature(doc_cfg, doc_cfg_hide))]
+#![cfg_attr(no_std, feature(no_std))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![forbid(unsafe_code)]
+
+#[cfg(feature = "no_std")]
+extern crate alloc;
 
 #[macro_use]
 mod macros;
@@ -15,6 +19,9 @@ pub mod error;
 mod util;
 mod xz;
 
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 /// Compression helpers.

--- a/src/util/vec2d.rs
+++ b/src/util/vec2d.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "no_std")]
+use alloc::boxed::Box;
+#[cfg(feature = "no_std")]
+use core::ops::{Index, IndexMut};
+#[cfg(not(feature = "no_std"))]
 use std::ops::{Index, IndexMut};
 
 /// A 2 dimensional matrix in row-major order backed by a contiguous slice.

--- a/src/xz/header.rs
+++ b/src/xz/header.rs
@@ -5,6 +5,10 @@ use crate::error;
 use crate::xz::crc::CRC32;
 use crate::xz::StreamFlags;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
+use std::io;
 
 /// File format magic header signature, see sect. 2.1.1.1.
 pub(crate) const XZ_MAGIC: &[u8] = &[0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00];
@@ -19,7 +23,7 @@ impl StreamHeader {
     /// Parse a Stream Header from a buffered reader.
     pub(crate) fn parse<BR>(input: &mut BR) -> error::Result<Self>
     where
-        BR: std::io::BufRead,
+        BR: io::BufRead,
     {
         if !util::read_tag(input, XZ_MAGIC)? {
             return Err(error::Error::XzError(format!(

--- a/src/xz/mod.rs
+++ b/src/xz/mod.rs
@@ -5,6 +5,9 @@
 //! [spec]: https://tukaani.org/xz/xz-file-format.txt
 
 use crate::error;
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 pub(crate) mod crc;
@@ -85,12 +88,19 @@ impl From<CheckMethod> for u8 {
 mod test {
     use super::*;
     use byteorder::{BigEndian, ReadBytesExt};
-    use std::io::{Seek, SeekFrom};
+    #[cfg(feature = "no_std")]
+    use core::u8::MAX as U8_MAX;
+    #[cfg(feature = "no_std")]
+    use core2::io::{self, Seek, SeekFrom};
+    #[cfg(not(feature = "no_std"))]
+    use std::io::{self, Seek, SeekFrom};
+    #[cfg(not(feature = "no_std"))]
+    use std::u8::MAX as U8_MAX;
 
     #[test]
     fn test_checkmethod_roundtrip() {
         let mut count_valid = 0;
-        for input in 0..std::u8::MAX {
+        for input in 0..U8_MAX {
             if let Ok(check) = CheckMethod::try_from(input) {
                 let output: u8 = check.into();
                 assert_eq!(input, output);
@@ -106,7 +116,7 @@ mod test {
             check_method: CheckMethod::Crc32,
         };
 
-        let mut cursor = std::io::Cursor::new(vec![0u8; 2]);
+        let mut cursor = io::Cursor::new(vec![0u8; 2]);
         let len = input.serialize(&mut cursor).unwrap();
         assert_eq!(len, 2);
 


### PR DESCRIPTION
### Pull Request Overview

Add a default `std` feature, and use compatible data structures from `alloc`, `core`, and `core2` for `no-std` builds.

To build for `no-std` pass `--no-default-features` on the command line, or `default-features = false` in the Cargo.toml of another library/binary using `lzma-rs`.

### Testing Strategy

This pull request was tested by...

- [ ] Added relevant unit tests.
- [ ] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).

Building and testing with the new `std` feature, and with `no-default-features`.