### PR TITLE
Add support for `no_std`

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -8,5 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+      - name: Install liblzma-dev
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
       - name: Build benches
-        run: cargo build --benches --verbose
+        run: cargo +nightly build --benches --verbose
+      - name: Build benches (no default features)
+        run: cargo +nightly build --no-default-features --benches --verbose

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,6 +8,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install liblzma-dev
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lib --lcov --output-path lcov.info
       - name: Upload to Codecov
@@ -24,6 +27,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install liblzma-dev
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --test '*' --lcov --output-path lcov.info
       - name: Upload to Codecov

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-
+      - name: Install rustfmt
+        run: rustup component add rustfmt
       - name: Check formatting
         run: cargo fmt --verbose -- --check --verbose
       - name: Check formatting on fuzzing

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo fuzz
-        run: cargo install cargo-fuzz --verbose
+        run: cargo +nightly install cargo-fuzz --verbose
       - name: Build fuzz targets
-        run: cargo fuzz build --verbose
+        run: cargo +nightly fuzz build --verbose

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,7 +10,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
+      - name: Install liblzma-dev
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
+      - name: Install clippy
+        run: rustup component add clippy
       - name: Check Clippy lints
         run: cargo clippy --verbose --all-features -- -W clippy::match-same-arms
       - name: Check Clippy lints on tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Install liblzma-dev
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
+
       - name: Build with default features
         run: cargo build --verbose
       - name: Tests with default features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.71.0  # MSRV
+          - 1.78.0  # MSRV
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,3 +30,7 @@ jobs:
         run: cargo build --all-features --verbose
       - name: Tests with all features
         run: cargo test --all-features --verbose
+      - name: Build with no features (i.e., `no_std`)
+        run: cargo build --no-default-features --verbose
+      - name: Test with no features (i.e., `no_std`)
+        run: cargo test --no-default-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ rust-lzma = "0.6"
 seq-macro = "0.3"
 
 [features]
+default = ["std"]
 enable_logging = ["env_logger", "log"]
-stream = []
+std = []
+stream = ["std"]
 raw_decoder = []
 
 [package.metadata.docs.rs]
-features = ["stream", "raw_decoder"]
+features = ["std", "stream", "raw_decoder"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rust-version = "1.78.0"
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = { version = "1.4.3", default-features = false }
 crc = "3.0.0"
 log = { version = "0.4.17", optional = true }
 env_logger = { version = "0.11.3", optional = true }
@@ -25,7 +25,7 @@ seq-macro = "0.3"
 [features]
 default = ["std"]
 enable_logging = ["env_logger", "log"]
-std = []
+std = ["byteorder/std"]
 stream = ["std"]
 raw_decoder = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["compression"]
 keywords = ["lzma", "compression", "decompression"]
 exclude = ["tests/*", "benches/*", "fuzz/*", ".github/*", "Cargo.lock"]
 edition = "2018"
-rust-version = "1.71.0"
+rust-version = "1.78.0"
 
 [dependencies]
 byteorder = "1.4.3"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ lzma_rs::xz_decompress(&mut f, &mut decomp).unwrap();
 // Decompressed content is now in "decomp"
 ```
 
+Compress a slice into a vector in a `no_std` environment.
+```rust
+#![no_std]
+extern crate alloc;
+use alloc::vec::Vec;
+
+let data: &[u8] = gather_my_data();
+let compressed_data: Vec<u8> = Vec::new();
+
+lzma_rs::lzma_compress(&mut lzma_compress::io::Cursor::new(data), compressed_data).unwrap();
+// Compressed content is now in decomp
+```
+
 ## Encoder
 
 For now, there is also a dumb encoder that only uses byte literals, with many hard-coded constants for code simplicity.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crate](https://img.shields.io/crates/v/lzma-rs.svg?logo=rust)](https://crates.io/crates/lzma-rs)
 [![Documentation](https://img.shields.io/docsrs/lzma-rs?logo=rust)](https://docs.rs/lzma-rs)
-[![Minimum Rust 1.71](https://img.shields.io/badge/rust-1.71%2B-orange.svg?logo=rust)](https://releases.rs/docs/1.71.0/)
+[![Minimum Rust 1.78](https://img.shields.io/badge/rust-1.78%2B-orange.svg?logo=rust)](https://releases.rs/docs/1.78.0/)
 [![Dependencies](https://deps.rs/repo/github/gendx/lzma-rs/status.svg)](https://deps.rs/repo/github/gendx/lzma-rs)
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg?logo=rust)](https://github.com/rust-secure-code/safety-dance/)
 ![Build Status](https://github.com/gendx/lzma-rs/workflows/Build%20and%20run%20tests/badge.svg)

--- a/benches/lzma.rs
+++ b/benches/lzma.rs
@@ -8,17 +8,17 @@ use test::Bencher;
 fn compress_bench(x: &[u8], b: &mut Bencher) {
     b.iter(|| {
         let mut compressed: Vec<u8> = Vec::new();
-        lzma_rs::lzma_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
+        lzma_rs::lzma_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed).unwrap();
         compressed
     });
 }
 
 fn decompress_after_compress_bench(x: &[u8], b: &mut Bencher) {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::lzma_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
+    lzma_rs::lzma_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed).unwrap();
 
     b.iter(|| {
-        let mut bf = std::io::BufReader::new(compressed.as_slice());
+        let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
         let mut decomp: Vec<u8> = Vec::new();
         lzma_rs::lzma_decompress(&mut bf, &mut decomp).unwrap();
         decomp
@@ -27,7 +27,7 @@ fn decompress_after_compress_bench(x: &[u8], b: &mut Bencher) {
 
 fn decompress_bench(compressed: &[u8], b: &mut Bencher) {
     b.iter(|| {
-        let mut bf = std::io::BufReader::new(compressed);
+        let mut bf = lzma_rs::io::BufReader::new(compressed);
         let mut decomp: Vec<u8> = Vec::new();
         lzma_rs::lzma_decompress(&mut bf, &mut decomp).unwrap();
         decomp

--- a/fuzz/fuzz_targets/interop_xz_encode.rs
+++ b/fuzz/fuzz_targets/interop_xz_encode.rs
@@ -8,7 +8,7 @@ use xz2::stream;
 
 fn encode_xz_lzmars(x: &[u8]) -> Result<Vec<u8>> {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::xz_compress(&mut std::io::BufReader::new(x), &mut compressed)?;
+    lzma_rs::xz_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed)?;
     Ok(compressed)
 }
 

--- a/fuzz/fuzz_targets/roundtrip_lzma.rs
+++ b/fuzz/fuzz_targets/roundtrip_lzma.rs
@@ -6,8 +6,8 @@ use lzma_rs::error::Result;
 
 fn round_trip_lzma(x: &[u8]) -> Result<Vec<u8>> {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::lzma_compress(&mut std::io::BufReader::new(x), &mut compressed)?;
-    let mut bf = std::io::BufReader::new(compressed.as_slice());
+    lzma_rs::lzma_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed)?;
+    let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
 
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma_decompress(&mut bf, &mut decomp)?;

--- a/fuzz/fuzz_targets/roundtrip_lzma2.rs
+++ b/fuzz/fuzz_targets/roundtrip_lzma2.rs
@@ -6,8 +6,8 @@ use lzma_rs::error::Result;
 
 fn round_trip_lzma2(x: &[u8]) -> Result<Vec<u8>> {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::lzma2_compress(&mut std::io::BufReader::new(x), &mut compressed)?;
-    let mut bf = std::io::BufReader::new(compressed.as_slice());
+    lzma_rs::lzma2_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed)?;
+    let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
 
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma2_decompress(&mut bf, &mut decomp)?;

--- a/fuzz/fuzz_targets/roundtrip_xz.rs
+++ b/fuzz/fuzz_targets/roundtrip_xz.rs
@@ -6,8 +6,8 @@ use lzma_rs::error::Result;
 
 fn round_trip_xz(x: &[u8]) -> Result<Vec<u8>> {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::xz_compress(&mut std::io::BufReader::new(x), &mut compressed)?;
-    let mut bf = std::io::BufReader::new(compressed.as_slice());
+    lzma_rs::xz_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed)?;
+    let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
 
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::xz_decompress(&mut bf, &mut decomp)?;

--- a/src/decode/lzbuffer.rs
+++ b/src/decode/lzbuffer.rs
@@ -1,5 +1,6 @@
-use crate::error;
-use std::io;
+use crate::{error, io};
+use alloc::format;
+use alloc::vec::Vec;
 
 pub trait LzBuffer<W>
 where
@@ -339,6 +340,11 @@ mod test {
 
         fn flush(&mut self) -> Result<(), io::Error> {
             self.flushed.append(&mut self.unflushed);
+            Ok(())
+        }
+
+        fn write_all(&mut self, buf: &[u8]) -> Result<(), io::Error> {
+            self.unflushed.extend_from_slice(buf);
             Ok(())
         }
     }

--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -1,10 +1,12 @@
 use crate::decode::lzbuffer::{LzBuffer, LzCircularBuffer};
 use crate::decode::rangecoder::{BitTree, LenDecoder, RangeDecoder};
 use crate::decompress::{Options, UnpackedSize};
-use crate::error;
 use crate::util::vec2d::Vec2D;
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::io;
+use crate::{error, io};
+use alloc::format;
+use alloc::string::String;
+use byteorder::LittleEndian;
+use io::ReadBytes;
 
 /// Maximum input data that can be processed in one iteration.
 /// Libhtp uses the following equation to define the maximum number of bits
@@ -165,7 +167,7 @@ impl LzmaParams {
 pub(crate) struct DecoderState {
     // Buffer input data here if we need more for decompression. Up to
     // MAX_REQUIRED_INPUT bytes can be consumed during one iteration.
-    partial_input_buf: std::io::Cursor<[u8; MAX_REQUIRED_INPUT]>,
+    partial_input_buf: io::Cursor<[u8; MAX_REQUIRED_INPUT]>,
     pub(crate) lzma_props: LzmaProperties,
     unpacked_size: Option<u64>,
     literal_probs: Vec2D<u16>,
@@ -188,7 +190,7 @@ impl DecoderState {
     pub fn new(lzma_props: LzmaProperties, unpacked_size: Option<u64>) -> Self {
         lzma_props.validate();
         DecoderState {
-            partial_input_buf: std::io::Cursor::new([0; MAX_REQUIRED_INPUT]),
+            partial_input_buf: io::Cursor::new([0; MAX_REQUIRED_INPUT]),
             lzma_props,
             unpacked_size,
             literal_probs: Vec2D::init(0x400, (1 << (lzma_props.lc + lzma_props.lp), 0x300)),
@@ -412,7 +414,7 @@ impl DecoderState {
         range: u32,
         code: u32,
     ) -> error::Result<()> {
-        let mut temp = std::io::Cursor::new(buf);
+        let mut temp = io::Cursor::new(buf);
         let mut rangecoder = RangeDecoder::from_parts(&mut temp, range, code);
         let _ = self.process_next_inner(output, &mut rangecoder, false)?;
         Ok(())

--- a/src/decode/lzma2.rs
+++ b/src/decode/lzma2.rs
@@ -1,10 +1,15 @@
 use crate::decode::lzbuffer::LzBuffer;
 use crate::decode::lzma::{DecoderState, LzmaProperties};
 use crate::decode::{lzbuffer, rangecoder};
-use crate::error;
-use byteorder::{BigEndian, ReadBytesExt};
-use std::io;
-use std::io::Read;
+use crate::{error, io};
+use io::ReadBytes;
+
+#[cfg(feature = "std")]
+use io::Read;
+
+use alloc::{format, vec};
+
+use byteorder::BigEndian;
 
 #[derive(Debug)]
 /// Raw decoder for LZMA2.

--- a/src/decode/rangecoder.rs
+++ b/src/decode/rangecoder.rs
@@ -1,8 +1,8 @@
 use crate::decode::util;
-use crate::error;
+use crate::io::ReadBytes;
 use crate::util::const_assert;
-use byteorder::{BigEndian, ReadBytesExt};
-use std::io;
+use crate::{error, io};
+use byteorder::BigEndian;
 
 pub struct RangeDecoder<'a, R>
 where

--- a/src/decode/stream.rs
+++ b/src/decode/stream.rs
@@ -236,13 +236,10 @@ where
                         let position = self.tmp.position();
                         let bytes_read =
                             input.read(&mut self.tmp.get_mut()[position as usize..])?;
-                        let bytes_read = if bytes_read < std::u64::MAX as usize {
+                        let bytes_read = if bytes_read < u64::MAX as usize {
                             bytes_read as u64
                         } else {
-                            return Err(io::Error::new(
-                                io::ErrorKind::Other,
-                                "Failed to convert integer to u64.",
-                            ));
+                            return Err(io::Error::other("Failed to convert integer to u64."));
                         };
                         self.tmp.set_position(position + bytes_read);
 
@@ -277,11 +274,10 @@ where
                                 // reset the cursor because we may have partial reads
                                 input.set_position(0);
                                 let bytes_read = input.read(&mut self.tmp.get_mut()[..])?;
-                                let bytes_read = if bytes_read < std::u64::MAX as usize {
+                                let bytes_read = if bytes_read < u64::MAX as usize {
                                     bytes_read as u64
                                 } else {
-                                    return Err(io::Error::new(
-                                        io::ErrorKind::Other,
+                                    return Err(io::Error::other(
                                         "Failed to convert integer to u64.",
                                     ));
                                 };
@@ -299,9 +295,7 @@ where
                         Err(e) => {
                             return Err(match e {
                                 Error::IoError(e) | Error::HeaderTooShort(e) => e,
-                                Error::LzmaError(e) | Error::XzError(e) => {
-                                    io::Error::new(io::ErrorKind::Other, e)
-                                }
+                                Error::LzmaError(e) | Error::XzError(e) => io::Error::other(e),
                             });
                         }
                     }
@@ -341,7 +335,7 @@ where
 
 impl From<Error> for io::Error {
     fn from(error: Error) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, format!("{:?}", error))
+        io::Error::other(format!("{:?}", error))
     }
 }
 

--- a/src/decode/util.rs
+++ b/src/decode/util.rs
@@ -56,7 +56,7 @@ where
     }
 }
 
-impl<'a, 'b, R> io::Read for CrcDigestRead<'a, 'b, R, u32>
+impl<R> io::Read for CrcDigestRead<'_, '_, R, u32>
 where
     R: io::Read,
 {
@@ -114,7 +114,7 @@ where
     }
 }
 
-impl<'a, R> io::Read for CountBufRead<'a, R>
+impl<R> io::Read for CountBufRead<'_, R>
 where
     R: io::BufRead,
 {
@@ -150,7 +150,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<'a, R> std::io::BufRead for CountBufRead<'a, R>
+impl<R> std::io::BufRead for CountBufRead<'_, R>
 where
     R: std::io::BufRead,
 {

--- a/src/decode/util.rs
+++ b/src/decode/util.rs
@@ -1,4 +1,5 @@
-use std::io;
+use crate::io;
+use alloc::vec;
 
 pub fn read_tag<R: io::BufRead>(input: &mut R, tag: &[u8]) -> io::Result<bool> {
     let mut buf = vec![0; tag.len()];
@@ -64,6 +65,29 @@ where
         self.digest.update(&buf[..result]);
         Ok(result)
     }
+
+    #[cfg(not(feature = "std"))]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.read.read_exact(buf)?;
+        self.digest.update(buf);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn reader_position(&self) -> io::Result<usize> {
+        self.read.reader_position()
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn advance_reader_position(&mut self, amt: usize) -> io::Result<()> {
+        self.digest.update(&self.read.get_remaining()?[..amt]);
+        self.read.advance_reader_position(amt)
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn get_remaining(&self) -> io::Result<&[u8]> {
+        self.read.get_remaining()
+    }
 }
 
 /// An [`io::BufRead`] counting the bytes read.
@@ -99,13 +123,38 @@ where
         self.count += result;
         Ok(result)
     }
+
+    #[cfg(not(feature = "std"))]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.read.read_exact(buf)?;
+        self.count += buf.len();
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn reader_position(&self) -> io::Result<usize> {
+        self.read.reader_position()
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn advance_reader_position(&mut self, amt: usize) -> io::Result<()> {
+        self.read.advance_reader_position(amt)?;
+        self.count += amt;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn get_remaining(&self) -> io::Result<&[u8]> {
+        self.read.get_remaining()
+    }
 }
 
-impl<'a, R> io::BufRead for CountBufRead<'a, R>
+#[cfg(feature = "std")]
+impl<'a, R> std::io::BufRead for CountBufRead<'a, R>
 where
-    R: io::BufRead,
+    R: std::io::BufRead,
 {
-    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
         self.read.fill_buf()
     }
 

--- a/src/decode/xz.rs
+++ b/src/decode/xz.rs
@@ -1,13 +1,18 @@
 //! Decoder for the `.xz` file format.
 
+use crate::alloc::string::ToString;
 use crate::decode::lzma2::Lzma2Decoder;
 use crate::decode::util;
-use crate::error;
+use crate::{error, io};
+use io::Read;
+
 use crate::xz::crc::{CRC32, CRC64};
 use crate::xz::{footer, header, CheckMethod, StreamFlags};
-use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
-use std::io;
-use std::io::Read;
+use byteorder::{BigEndian, LittleEndian};
+use io::ReadBytes;
+
+use alloc::vec::Vec;
+use alloc::{format, vec};
 
 #[derive(Debug)]
 struct Record {
@@ -239,11 +244,7 @@ where
             }
         } else {
             let mut newbuf: Vec<u8> = Vec::new();
-            decode_filter(
-                &mut io::BufReader::new(tmpbuf.as_slice()),
-                &mut newbuf,
-                filter,
-            )?;
+            decode_filter(&mut io::Cursor::new(tmpbuf.as_slice()), &mut newbuf, filter)?;
             // TODO: does this move or copy?
             tmpbuf = newbuf;
         }

--- a/src/encode/dumbencoder.rs
+++ b/src/encode/dumbencoder.rs
@@ -69,6 +69,8 @@ where
         let mut prev_byte = 0u8;
         let mut input_len = 0;
 
+        #[allow(unknown_lints)]
+        #[allow(clippy::unbuffered_bytes)]
         for (out_len, byte_result) in input.bytes().enumerate() {
             let byte = byte_result?;
             let pos_state = out_len & 3;

--- a/src/encode/dumbencoder.rs
+++ b/src/encode/dumbencoder.rs
@@ -1,7 +1,8 @@
 use crate::compress::{Options, UnpackedSize};
 use crate::encode::rangecoder;
-use byteorder::{LittleEndian, WriteBytesExt};
-use std::io;
+use crate::io;
+use byteorder::LittleEndian;
+use io::WriteBytes;
 
 pub struct Encoder<'a, W>
 where

--- a/src/encode/lzma2.rs
+++ b/src/encode/lzma2.rs
@@ -1,5 +1,7 @@
-use byteorder::{BigEndian, WriteBytesExt};
-use std::io;
+use crate::io;
+use alloc::vec;
+use byteorder::BigEndian;
+use io::WriteBytes;
 
 pub fn encode_stream<R, W>(input: &mut R, output: &mut W) -> io::Result<()>
 where

--- a/src/encode/options.rs
+++ b/src/encode/options.rs
@@ -2,7 +2,7 @@
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Options {
     /// Defines whether the unpacked size should be written to the header.
-    /// The default is [`UnpackedSize::WriteToHeader(None)`].
+    /// The default is [`UnpackedSize::WriteToHeader`] with no specified value.
     pub unpacked_size: UnpackedSize,
 }
 

--- a/src/encode/rangecoder.rs
+++ b/src/encode/rangecoder.rs
@@ -1,5 +1,5 @@
-use byteorder::WriteBytesExt;
-use std::io;
+use crate::io;
+use io::WriteBytes;
 
 #[cfg(test)]
 use crate::util::const_assert;
@@ -278,8 +278,9 @@ mod test {
     use super::*;
     use crate::decode::rangecoder::{LenDecoder, RangeDecoder};
     use crate::{decode, encode};
+    use alloc::vec::Vec;
+    use io::BufReader;
     use seq_macro::seq;
-    use std::io::BufReader;
 
     fn encode_decode(prob_init: u16, bits: &[bool]) {
         let mut buf: Vec<u8> = Vec::new();

--- a/src/encode/util.rs
+++ b/src/encode/util.rs
@@ -22,7 +22,7 @@ where
     }
 }
 
-impl<'a, 'b, W> io::Write for CrcDigestWrite<'a, 'b, W, u32>
+impl<W> io::Write for CrcDigestWrite<'_, '_, W, u32>
 where
     W: io::Write,
 {
@@ -38,7 +38,7 @@ where
     #[cfg(not(feature = "std"))]
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         self.write.write_all(buf)?;
-        self.digest.update(&buf);
+        self.digest.update(buf);
         Ok(())
     }
 }
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl<'a, W> io::Write for CountWrite<'a, W>
+impl<W> io::Write for CountWrite<'_, W>
 where
     W: io::Write,
 {

--- a/src/encode/util.rs
+++ b/src/encode/util.rs
@@ -1,4 +1,4 @@
-use std::io;
+use crate::io;
 
 /// An [`io::Write`] computing a digest on the bytes written.
 pub struct CrcDigestWrite<'a, 'b, W, S>
@@ -33,6 +33,13 @@ where
     }
     fn flush(&mut self) -> io::Result<()> {
         self.write.flush()
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.write.write_all(buf)?;
+        self.digest.update(&buf);
+        Ok(())
     }
 }
 
@@ -72,5 +79,12 @@ where
 
     fn flush(&mut self) -> io::Result<()> {
         self.write.flush()
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.write.write_all(buf)?;
+        self.count += buf.len();
+        Ok(())
     }
 }

--- a/src/encode/xz.rs
+++ b/src/encode/xz.rs
@@ -1,10 +1,13 @@
-use crate::decode;
 use crate::encode::{lzma2, util};
 use crate::xz::crc::CRC32;
 use crate::xz::{footer, header, CheckMethod, StreamFlags};
-use byteorder::{LittleEndian, WriteBytesExt};
-use std::io;
-use std::io::Write;
+use crate::{decode, io};
+use alloc::vec;
+use alloc::vec::Vec;
+use byteorder::LittleEndian;
+use io::WriteBytes;
+
+use io::Write;
 
 pub fn encode_stream<R, W>(input: &mut R, output: &mut W) -> io::Result<()>
 where

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error handling.
 
-use std::fmt::Display;
-use std::{io, result};
+use crate::io;
+use alloc::string::String;
 
 /// Library errors.
 #[derive(Debug)]
@@ -17,16 +17,16 @@ pub enum Error {
 }
 
 /// Library result alias.
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Error {
+    fn from(e: io::Error) -> Self {
         Error::IoError(e)
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::IoError(e) => write!(fmt, "io error: {}", e),
             Error::HeaderTooShort(e) => write!(fmt, "header too short: {}", e),
@@ -36,8 +36,8 @@ impl Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Error::IoError(e) | Error::HeaderTooShort(e) => Some(e),
             Error::LzmaError(_) | Error::XzError(_) => None,
@@ -48,17 +48,23 @@ impl std::error::Error for Error {
 #[cfg(test)]
 mod test {
     use super::Error;
+    use crate::io;
+    use alloc::string::ToString;
 
     #[test]
     fn test_display() {
+        #[cfg(feature = "std")]
         assert_eq!(
-            Error::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "this is an error"
-            ))
-            .to_string(),
+            Error::IoError(io::Error::new(std::io::ErrorKind::Other, "this is an error")).to_string(),
             "io error: this is an error"
         );
+
+        #[cfg(not(feature = "std"))]
+        assert_eq!(
+            Error::IoError(io::Error::OutOfSpace).to_string(),
+            "io error: OutOfSpace"
+        );
+
         assert_eq!(
             Error::LzmaError("this is an error".to_string()).to_string(),
             "lzma error: this is an error"

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,8 +36,9 @@ impl core::fmt::Display for Error {
     }
 }
 
-impl core::error::Error for Error {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::IoError(e) | Error::HeaderTooShort(e) => Some(e),
             Error::LzmaError(_) | Error::XzError(_) => None,
@@ -55,7 +56,7 @@ mod test {
     fn test_display() {
         #[cfg(feature = "std")]
         assert_eq!(
-            Error::IoError(io::Error::new(std::io::ErrorKind::Other, "this is an error")).to_string(),
+            Error::IoError(io::Error::other("this is an error")).to_string(),
             "io error: this is an error"
         );
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,19 @@
+//! IO handling.
+//!
+//! With the `std` feature enabled, the IO module re-exports relevant IO
+//! constructs from `std::io`. Under `no_std` conditions, the IO module
+//! exports a minimal implementation of IO for reading from
+//! [`Cursor<AsRef<[u8]>>`], and writing to [`Cursor<&[u8]>`],
+//! [`Cursor<Vec<u8>>`], and `[Vec<u8>`].
+
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use byteorder::{ReadBytesExt as ReadBytes, WriteBytesExt as WriteBytes};
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use std::io::{BufRead, BufReader, Cursor, Error, Read, Result, Write};
+
+#[cfg(not(feature = "std"))]
+mod nostd;
+#[cfg(not(feature = "std"))]
+pub use nostd::*;

--- a/src/io/nostd.rs
+++ b/src/io/nostd.rs
@@ -10,6 +10,7 @@
 use alloc::vec::Vec;
 use byteorder;
 use core::cmp;
+use core::mem::size_of;
 
 #[derive(Debug, PartialEq, Eq)]
 /// An IO error
@@ -24,7 +25,6 @@ pub enum Error {
     InvalidCursor,
 }
 
-impl core::error::Error for Error {}
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "{:?}", self)
@@ -95,7 +95,7 @@ impl<R: Read> Iterator for ByteIterator<R> {
         let buffer_result = self.reader.get_remaining();
 
         if let Ok(buffer) = buffer_result {
-            if buffer.len() == 0 {
+            if buffer.is_empty() {
                 return None;
             }
             let byte: u8 = buffer[0];
@@ -107,7 +107,7 @@ impl<R: Read> Iterator for ByteIterator<R> {
             return Some(Ok(byte));
         }
 
-        return Some(Err(buffer_result.unwrap_err()));
+        Some(Err(buffer_result.unwrap_err()))
     }
 }
 
@@ -136,7 +136,7 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
         if self.pos > self.inner.as_ref().len() {
             Err(Error::InvalidCursor)
         } else {
-            Ok(self.pos as usize)
+            Ok(self.pos)
         }
     }
 
@@ -157,9 +157,7 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
 
     fn read(&mut self, dest: &mut [u8]) -> Result<usize> {
         let num_bytes = core::cmp::min(dest.len(), self.get_remaining()?.len());
-        dest[..num_bytes].copy_from_slice(
-            &self.inner.as_ref()[self.pos as usize..(self.pos as usize + num_bytes)],
-        );
+        dest[..num_bytes].copy_from_slice(&self.inner.as_ref()[self.pos..(self.pos + num_bytes)]);
         self.advance_reader_position(num_bytes)?;
         Ok(num_bytes)
     }
@@ -176,7 +174,7 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
 }
 
 /// Implement `Read` for a mutable reference to a `Read` type
-impl<'a, T: Read + ?Sized> Read for &'a mut T {
+impl<T: Read> Read for &mut T {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         (**self).read(buf)
     }
@@ -220,30 +218,29 @@ pub trait Write {
 /// All `Cursor<&mut [u8]>` can be written to.
 /// This implementation will write to the underlying non-resizable slice,
 /// overwriting the data at the current cursor position.
-impl<'a> Write for Cursor<&'a mut [u8]> {
+impl Write for Cursor<&mut [u8]> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         // Return an error if the cursor is already out-of-bounds
-        if self.pos as usize > self.inner.len() {
+        if self.pos > self.inner.len() {
             return Err(Error::InvalidCursor);
         }
 
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return Ok(0);
         }
 
-        let num_bytes = cmp::min(buf.len(), self.inner.len() - self.pos as usize);
-        self.inner[self.pos as usize..(self.pos as usize + num_bytes)]
-            .copy_from_slice(&buf[..num_bytes]);
+        let num_bytes = cmp::min(buf.len(), self.inner.len() - self.pos);
+        self.inner[self.pos..(self.pos + num_bytes)].copy_from_slice(&buf[..num_bytes]);
         self.pos += num_bytes;
         Ok(num_bytes)
     }
 
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        if self.pos as usize + buf.len() > self.inner.len() {
+        if self.pos + buf.len() > self.inner.len() {
             return Err(Error::OutOfSpace);
         }
 
-        self.inner[self.pos as usize..(self.pos as usize + buf.len())].copy_from_slice(buf);
+        self.inner[self.pos..(self.pos + buf.len())].copy_from_slice(buf);
         self.pos += buf.len();
         Ok(())
     }
@@ -270,7 +267,7 @@ impl Write for Vec<u8> {
 impl Write for Cursor<Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         // Return an error if the cursor is already out-of-bounds
-        if self.pos as usize > self.inner.len() {
+        if self.pos > self.inner.len() {
             return Err(Error::InvalidCursor);
         }
 
@@ -278,14 +275,14 @@ impl Write for Cursor<Vec<u8>> {
         let bytes_over = (self.pos + buf.len()).saturating_sub(self.inner.len());
         let (bytes_to_splice, bytes_to_extend) = buf.split_at(buf.len() - bytes_over);
 
-        if bytes_to_splice.len() > 0 {
+        if !bytes_to_splice.is_empty() {
             self.inner.splice(
                 self.pos..self.pos + bytes_to_splice.len(),
                 bytes_to_splice.iter().cloned(),
             );
         }
 
-        if bytes_to_extend.len() > 0 {
+        if !bytes_to_extend.is_empty() {
             self.inner.extend_from_slice(bytes_to_extend)
         }
 
@@ -303,7 +300,7 @@ impl Write for Cursor<Vec<u8>> {
     }
 }
 
-impl<'a, T: Write + ?Sized> Write for &'a mut T {
+impl<T: Write + ?Sized> Write for &mut T {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         (*self).write(buf)
     }
@@ -438,7 +435,7 @@ pub struct Take<'a, R: Read> {
     bytes_remaining: usize,
 }
 
-impl<'a, R: Read> Read for Take<'a, R> {
+impl<R: Read> Read for Take<'_, R> {
     fn reader_position(&self) -> Result<usize> {
         self.inner.reader_position()
     }
@@ -450,7 +447,7 @@ impl<'a, R: Read> Read for Take<'a, R> {
         self.inner.advance_reader_position(amt)?;
         self.bytes_remaining -= amt;
 
-        return Ok(());
+        Ok(())
     }
 
     fn get_remaining(&self) -> Result<&[u8]> {
@@ -480,7 +477,7 @@ pub trait IntoReader<R: Read> {
     fn into_reader(self) -> R;
 }
 
-impl<'a, R: Read> IntoReader<R> for R {
+impl<R: Read> IntoReader<R> for R {
     fn into_reader(self) -> R {
         self
     }
@@ -502,27 +499,9 @@ impl BufReader {
     /// Convert the provided type into a `Read` type. Types which already
     /// implement `Read` will return themselves, and types that implement
     /// `AsRef<[u8]>` will return a `Cursor` over the data.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<T: IntoReader<R>, R: Read>(reader: T) -> R {
         reader.into_reader()
-    }
-}
-
-/// Helper trait to convert valid writers into a type implementing [`Write`]
-/// type. Valid for `Vec<u8>`, `&mut [u8]`, and any type implementing [`Write`].
-pub trait IntoWriter {
-    /// Convert the type into a `Write` type.
-    fn into_writer(self) -> impl Write;
-}
-
-impl<W: Write> IntoWriter for W {
-    fn into_writer(self) -> impl Write {
-        self
-    }
-}
-
-impl<'a> IntoWriter for &'a mut [u8] {
-    fn into_writer(self) -> impl Write {
-        Cursor::new(self)
     }
 }
 

--- a/src/io/nostd.rs
+++ b/src/io/nostd.rs
@@ -1,0 +1,693 @@
+///
+/// Minimal implementations of [`std::io`] constructs used
+///
+/// Readers are implemented for all [`Cursor<AsRef<[u8]>>`]
+/// As all data is already stored in buffers, BufRead is implemented for all
+/// readers
+///
+/// Writers are implemented for all [`Cursor<AsRef<[u8]>>`] as well as
+/// [`Cursor<Vec<u8>>`] and [`Vec<u8>`]
+use alloc::vec::Vec;
+use byteorder;
+use core::cmp;
+
+#[derive(Debug, PartialEq, Eq)]
+/// An IO error
+pub enum Error {
+    /// A write failed due to a lack of buffer space
+    OutOfSpace,
+
+    /// An unexpected end-of-input was reached
+    EndOfInput,
+
+    /// A cursor's position is invalid
+    InvalidCursor,
+}
+
+impl core::error::Error for Error {}
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// A `no_std` analogue of `std::io::Result``
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// A tailored `no_std` Read trait that assumes an underlying data slice.
+///
+/// This trait defines the behavior of a positioned `no_std` reader that is able
+/// to return all remaining data on demand. It is intended as a `no_std`
+/// adaptatation and extension of `std::io::Read` that is tailored for reading
+/// data already fully loaded into memory.
+pub trait Read
+where
+    Self: Sized,
+{
+    /// Get the position of the reader, returning an error if the position is
+    /// invalid.
+    fn reader_position(&self) -> Result<usize>;
+
+    /// Advance the reader position by a specified amount, returning an error if
+    /// the position is out-of-bounds.
+    fn advance_reader_position(&mut self, amt: usize) -> Result<()>;
+
+    /// Get all data after the current reader position as a slice.
+    fn get_remaining(&self) -> Result<&[u8]>;
+
+    /// Attempt to fill a destination buffer with data from the reader,
+    /// returning the number of bytes read. Intended to be an equivalent of
+    /// `std::io::Read::read`.
+    fn read(&mut self, dest: &mut [u8]) -> Result<usize>;
+
+    /// Attempt to completely fill a destination buffer with data from the
+    /// reader, returning an error if not enough data is available. Intended
+    /// to be an equivalent of `std::io::Read::read_exact`.
+    fn read_exact(&mut self, dest: &mut [u8]) -> Result<()>;
+
+    /// Creates a `Take` adapter that limits the number of bytes read from this
+    /// reader. Intended to be an equivalent of `std::io::Read::take`.
+    fn take(&mut self, limit: u64) -> Take<'_, Self> {
+        Take {
+            inner: self,
+            bytes_remaining: limit as usize,
+        }
+    }
+
+    /// Returns an iterator over the bytes of this reader.
+    /// Intended to be an equivalent of `std::io::Read::bytes`.
+    fn bytes(self) -> ByteIterator<Self> {
+        ByteIterator { reader: self }
+    }
+}
+
+/// An iterator over the bytes of a `Read` type, intended to be an equivalent of
+/// `std::io::Read::bytes`.
+#[derive(Debug)]
+pub struct ByteIterator<R: Read> {
+    reader: R,
+}
+
+impl<R: Read> Iterator for ByteIterator<R> {
+    type Item = Result<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let buffer_result = self.reader.get_remaining();
+
+        if let Ok(buffer) = buffer_result {
+            if buffer.len() == 0 {
+                return None;
+            }
+            let byte: u8 = buffer[0];
+
+            if let Err(e) = self.reader.advance_reader_position(1) {
+                return Some(Err(e));
+            }
+
+            return Some(Ok(byte));
+        }
+
+        return Some(Err(buffer_result.unwrap_err()));
+    }
+}
+
+/// A `no_std` analogue of `std::io::BufRead` that is implemented
+/// for all [`Read`] types.
+pub trait BufRead: Read {
+    /// Analogue of `std::io::BufRead::fill_buf`, returning the remaining data
+    /// in the reader as if the remaining data in memory has been buffered.
+    fn fill_buf(&self) -> Result<&[u8]> {
+        self.get_remaining()
+    }
+
+    /// Analogue of `std::io::BufRead::consume`, advancing the reader position
+    /// by a specified amount
+    fn consume(&mut self, amount: usize) {
+        self.advance_reader_position(amount).unwrap()
+    }
+}
+
+/// All [`Read`] types automatically implement [`BufRead`].
+impl<R: Read> BufRead for R {}
+
+impl<T: AsRef<[u8]>> Read for Cursor<T> {
+    fn reader_position(&self) -> Result<usize> {
+        // Ensure the position is within bounds
+        if self.pos > self.inner.as_ref().len() {
+            Err(Error::InvalidCursor)
+        } else {
+            Ok(self.pos as usize)
+        }
+    }
+
+    fn advance_reader_position(&mut self, amt: usize) -> Result<()> {
+        // Ensure the position would be within bounds after advancing
+        if self.pos + amt > self.inner.as_ref().len() {
+            Err(Error::InvalidCursor)
+        } else {
+            self.pos += amt;
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn get_remaining(&self) -> Result<&[u8]> {
+        Ok(&self.inner.as_ref()[self.reader_position()?..])
+    }
+
+    fn read(&mut self, dest: &mut [u8]) -> Result<usize> {
+        let num_bytes = core::cmp::min(dest.len(), self.get_remaining()?.len());
+        dest[..num_bytes].copy_from_slice(
+            &self.inner.as_ref()[self.pos as usize..(self.pos as usize + num_bytes)],
+        );
+        self.advance_reader_position(num_bytes)?;
+        Ok(num_bytes)
+    }
+
+    fn read_exact(&mut self, dest: &mut [u8]) -> Result<()> {
+        if dest.len() > self.get_remaining()?.len() {
+            Err(Error::EndOfInput)
+        } else {
+            dest.copy_from_slice(&self.get_remaining()?[..dest.len()]);
+            self.advance_reader_position(dest.len())?;
+            Ok(())
+        }
+    }
+}
+
+/// Implement `Read` for a mutable reference to a `Read` type
+impl<'a, T: Read + ?Sized> Read for &'a mut T {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        (**self).read(buf)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        (**self).read_exact(buf)
+    }
+
+    fn reader_position(&self) -> Result<usize> {
+        (**self).reader_position()
+    }
+
+    fn advance_reader_position(&mut self, amt: usize) -> Result<()> {
+        (**self).advance_reader_position(amt)
+    }
+
+    fn get_remaining(&self) -> Result<&[u8]> {
+        (**self).get_remaining()
+    }
+}
+
+/// A `no_std` equivalent of `std::io::Write` that is intended for writing bytes
+/// directly to memory without flushing.
+pub trait Write {
+    /// Write as much of the provided buffer as possible, returning the number
+    /// of bytes written.
+    /// Analogue of `std::io::Write::write`.
+    fn write(&mut self, buf: &[u8]) -> Result<usize>;
+
+    /// Attempt to write the entire provided buffer
+    /// Analogue of `std::io::Write::write_all`.
+    fn write_all(&mut self, buf: &[u8]) -> Result<()>;
+
+    /// Analogue of `std::io::Write::flush`.
+    fn flush(&mut self) -> Result<()> {
+        // There is nothign to flush in a `no_std` context.
+        Ok(())
+    }
+}
+
+/// All `Cursor<&mut [u8]>` can be written to.
+/// This implementation will write to the underlying non-resizable slice,
+/// overwriting the data at the current cursor position.
+impl<'a> Write for Cursor<&'a mut [u8]> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Return an error if the cursor is already out-of-bounds
+        if self.pos as usize > self.inner.len() {
+            return Err(Error::InvalidCursor);
+        }
+
+        if buf.len() == 0 {
+            return Ok(0);
+        }
+
+        let num_bytes = cmp::min(buf.len(), self.inner.len() - self.pos as usize);
+        self.inner[self.pos as usize..(self.pos as usize + num_bytes)]
+            .copy_from_slice(&buf[..num_bytes]);
+        self.pos += num_bytes;
+        Ok(num_bytes)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        if self.pos as usize + buf.len() > self.inner.len() {
+            return Err(Error::OutOfSpace);
+        }
+
+        self.inner[self.pos as usize..(self.pos as usize + buf.len())].copy_from_slice(buf);
+        self.pos += buf.len();
+        Ok(())
+    }
+}
+
+// All `Vec<u8>` can be written to.
+// This implementation will append to the end of the vector.
+impl Write for Vec<u8> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+}
+
+// All `Cursor<Vec<u8>>` can be written to.
+// This implementation will write to the underlying resizable vector,
+// overwriting the data at the current cursor position and extending the vector
+// as necessary.
+impl Write for Cursor<Vec<u8>> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Return an error if the cursor is already out-of-bounds
+        if self.pos as usize > self.inner.len() {
+            return Err(Error::InvalidCursor);
+        }
+
+        // Calculate the number of bytes that the vector needs to be extended by
+        let bytes_over = (self.pos + buf.len()).saturating_sub(self.inner.len());
+        let (bytes_to_splice, bytes_to_extend) = buf.split_at(buf.len() - bytes_over);
+
+        if bytes_to_splice.len() > 0 {
+            self.inner.splice(
+                self.pos..self.pos + bytes_to_splice.len(),
+                bytes_to_splice.iter().cloned(),
+            );
+        }
+
+        if bytes_to_extend.len() > 0 {
+            self.inner.extend_from_slice(bytes_to_extend)
+        }
+
+        self.set_position(self.position() + buf.len() as u64);
+
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        if self.write(buf)? < buf.len() {
+            Err(Error::OutOfSpace)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a, T: Write + ?Sized> Write for &'a mut T {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (*self).write(buf)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        (*self).write_all(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        (*self).flush()
+    }
+}
+
+/// A `no_std` analogue of `byteorder::ReadBytesExt` that allows for reading up
+/// to 64-bit integers.
+pub trait ReadBytes: Read {
+    /// Read a single byte from the reader.
+    fn read_u8(&mut self) -> Result<u8> {
+        let mut buf: [u8; 1] = [0];
+        self.read_exact(&mut buf)?;
+        Ok(buf[0])
+    }
+
+    /// Read a 16-bit unsigned integer from the reader with the specified byte
+    /// order.
+    fn read_u16<T: byteorder::ByteOrder>(&mut self) -> Result<u16> {
+        let mut buf: [u8; size_of::<u16>()] = [0; size_of::<u16>()];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u16(&buf))
+    }
+
+    /// Read a 32-bit unsigned integer from the reader with the specified byte
+    /// order.
+    fn read_u32<T: byteorder::ByteOrder>(&mut self) -> Result<u32> {
+        let mut buf: [u8; size_of::<u32>()] = [0; size_of::<u32>()];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u32(&buf))
+    }
+
+    /// Read a 64-bit unsigned integer from the reader with the specified byte
+    /// order.
+    fn read_u64<T: byteorder::ByteOrder>(&mut self) -> Result<u64> {
+        let mut buf: [u8; size_of::<u64>()] = [0; size_of::<u64>()];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u64(&buf))
+    }
+}
+
+/// A `no_std` analogue of `byteorder::WriteBytesExt` that allows for writing up
+/// to 64-bit integers.
+pub trait WriteBytes: Write {
+    /// Write a single byte to the writer.
+    fn write_u8(&mut self, n: u8) -> Result<()> {
+        let mut buf: [u8; 1] = [0];
+        buf[0] = n;
+        self.write_all(&buf)
+    }
+
+    /// Write a 16-bit unsigned integer to the writer with the specified byte
+    /// order.
+    fn write_u16<T: byteorder::ByteOrder>(&mut self, n: u16) -> Result<()> {
+        let mut buf: [u8; size_of::<u16>()] = [0; size_of::<u16>()];
+        T::write_u16(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Write a 32-bit unsigned integer to the writer with the specified byte
+    /// order.
+    fn write_u32<T: byteorder::ByteOrder>(&mut self, n: u32) -> Result<()> {
+        let mut buf: [u8; size_of::<u32>()] = [0; size_of::<u32>()];
+        T::write_u32(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Write a 64-bit unsigned integer to the writer with the specified byte
+    /// order.
+    fn write_u64<T: byteorder::ByteOrder>(&mut self, n: u64) -> Result<()> {
+        let mut buf: [u8; size_of::<u64>()] = [0; size_of::<u64>()];
+        T::write_u64(&mut buf, n);
+        self.write_all(&buf)
+    }
+}
+
+impl<R: Read> ReadBytes for R {}
+impl<W: Write> WriteBytes for W {}
+
+/// A `no_std` analogue of `std::io::Cursor` that allows defines a position
+/// within an inner type.
+#[derive(Debug)]
+pub struct Cursor<T> {
+    inner: T,
+    pos: usize,
+}
+
+impl<T> Cursor<T> {
+    /// Create a new `Cursor` with the specified inner type.
+    pub fn new(inner: T) -> Cursor<T> {
+        Cursor { inner, pos: 0 }
+    }
+
+    /// Get the inner value of the cursor.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Get a reference to the inner value of the cursor.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner value of the cursor.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Get the position of the cursor.
+    pub fn position(&self) -> u64 {
+        self.pos as u64
+    }
+
+    /// Set the position of the cursor.
+    pub fn set_position(&mut self, pos: u64) {
+        self.pos = pos as usize
+    }
+}
+
+/// A `no_std` analogue of `std::io::Take` that acts as an adapter for limiting
+/// the number of bytes read from a `Read` type.
+#[derive(Debug)]
+pub struct Take<'a, R: Read> {
+    inner: &'a mut R,
+    bytes_remaining: usize,
+}
+
+impl<'a, R: Read> Read for Take<'a, R> {
+    fn reader_position(&self) -> Result<usize> {
+        self.inner.reader_position()
+    }
+
+    fn advance_reader_position(&mut self, amt: usize) -> Result<()> {
+        if amt > self.bytes_remaining {
+            return Err(Error::InvalidCursor);
+        }
+        self.inner.advance_reader_position(amt)?;
+        self.bytes_remaining -= amt;
+
+        return Ok(());
+    }
+
+    fn get_remaining(&self) -> Result<&[u8]> {
+        Ok(&self.inner.get_remaining()?[..self.bytes_remaining])
+    }
+
+    fn read(&mut self, dest: &mut [u8]) -> Result<usize> {
+        let bytes_to_request = cmp::min(dest.len(), self.bytes_remaining);
+        let bytes_read = self.inner.read(&mut dest[..bytes_to_request])?;
+        self.bytes_remaining -= bytes_read;
+        Ok(bytes_read)
+    }
+
+    fn read_exact(&mut self, dest: &mut [u8]) -> Result<()> {
+        if dest.len() > self.bytes_remaining {
+            return Err(Error::EndOfInput);
+        }
+        self.inner.read_exact(dest)?;
+        self.bytes_remaining -= dest.len();
+        Ok(())
+    }
+}
+
+/// Helper trait to convert various types into a `Read` type for `BufReader`.
+pub trait IntoReader<R: Read> {
+    /// Convert the type into a `Read` type.
+    fn into_reader(self) -> R;
+}
+
+impl<'a, R: Read> IntoReader<R> for R {
+    fn into_reader(self) -> R {
+        self
+    }
+}
+
+impl<T: AsRef<[u8]>> IntoReader<Cursor<T>> for T {
+    fn into_reader(self) -> Cursor<T> {
+        Cursor::new(self)
+    }
+}
+
+/// A dummy equivalent of `std::io::BufReader` type that is used to provide a
+/// consistent interface for creating buffered readers. As all readers already
+/// have an internal buffer, this type does not provide any additional
+/// functionality.
+#[derive(Debug)]
+pub struct BufReader {}
+impl BufReader {
+    /// Convert the provided type into a `Read` type. Types which already
+    /// implement `Read` will return themselves, and types that implement
+    /// `AsRef<[u8]>` will return a `Cursor` over the data.
+    pub fn new<T: IntoReader<R>, R: Read>(reader: T) -> R {
+        reader.into_reader()
+    }
+}
+
+/// Helper trait to convert valid writers into a type implementing [`Write`]
+/// type. Valid for `Vec<u8>`, `&mut [u8]`, and any type implementing [`Write`].
+pub trait IntoWriter {
+    /// Convert the type into a `Write` type.
+    fn into_writer(self) -> impl Write;
+}
+
+impl<W: Write> IntoWriter for W {
+    fn into_writer(self) -> impl Write {
+        self
+    }
+}
+
+impl<'a> IntoWriter for &'a mut [u8] {
+    fn into_writer(self) -> impl Write {
+        Cursor::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn read_whole_cursor() {
+        const READ_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let mut cursor = Cursor::new(READ_BUFFER);
+
+        let dest_buffer: &mut [u8; READ_BUFFER.len()] = &mut [0; READ_BUFFER.len()];
+        assert!(cursor
+            .read(dest_buffer)
+            .is_ok_and(|len| len == READ_BUFFER.len()));
+        assert!(dest_buffer == READ_BUFFER);
+
+        assert_eq!(cursor.reader_position().unwrap(), READ_BUFFER.len());
+
+        // We shouldn't be able to read any more
+        assert!(cursor.read(dest_buffer).is_ok_and(|len| len == 0));
+    }
+
+    #[test]
+    fn read_partial_cursor() {
+        const READ_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+
+        // The following test is only valid if READ_BUFFER is of even length
+        assert!(READ_BUFFER.len() % 2 == 0);
+
+        let mut cursor = Cursor::new(READ_BUFFER);
+
+        let dest_buffer: &mut [u8; READ_BUFFER.len() / 2] = &mut [0; READ_BUFFER.len() / 2];
+
+        // Read the first half of the buffer
+        assert!(cursor
+            .read(dest_buffer)
+            .is_ok_and(|len| len == READ_BUFFER.len() / 2));
+        assert!(dest_buffer[..] == READ_BUFFER[..(READ_BUFFER.len() / 2)]);
+        assert_eq!(cursor.reader_position().unwrap(), READ_BUFFER.len() / 2);
+
+        // Read the second half of the buffer
+        assert!(cursor
+            .read(dest_buffer)
+            .is_ok_and(|len| len == READ_BUFFER.len() / 2));
+        assert!(dest_buffer[..] == READ_BUFFER[(READ_BUFFER.len() / 2)..]);
+        assert_eq!(cursor.reader_position().unwrap(), READ_BUFFER.len());
+    }
+
+    #[test]
+    fn read_exact_cursor() {
+        const READ_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let mut cursor = Cursor::new(READ_BUFFER);
+
+        let dest_buffer: &mut [u8; READ_BUFFER.len()] = &mut [0; READ_BUFFER.len()];
+        assert!(cursor.read_exact(dest_buffer).is_ok());
+        assert!(dest_buffer == READ_BUFFER);
+
+        assert_eq!(cursor.reader_position().unwrap(), READ_BUFFER.len());
+
+        // We shouldn't be able to read any more
+        assert_eq!(
+            cursor.read_exact(dest_buffer).unwrap_err(),
+            Error::EndOfInput
+        );
+    }
+
+    #[test]
+    fn read_exact_too_small() {
+        const READ_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let mut cursor = Cursor::new(READ_BUFFER);
+
+        let dest_buffer: &mut [u8; READ_BUFFER.len() * 2] = &mut [0; READ_BUFFER.len() * 2];
+        assert_eq!(
+            cursor.read_exact(dest_buffer).unwrap_err(),
+            Error::EndOfInput
+        );
+
+        // We didn't read anything, so the cursor shouldn't have moved
+        assert_eq!(cursor.reader_position().unwrap(), 0);
+    }
+
+    #[test]
+    fn bufread_cursor() {
+        const READ_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let mut cursor = Cursor::new(READ_BUFFER);
+
+        assert_eq!(cursor.get_remaining().unwrap(), cursor.fill_buf().unwrap());
+        assert_eq!(cursor.fill_buf().unwrap(), READ_BUFFER);
+
+        cursor.consume(READ_BUFFER.len() / 2);
+
+        assert_eq!(
+            cursor.get_remaining().unwrap(),
+            &READ_BUFFER[(READ_BUFFER.len() / 2)..]
+        );
+        assert_eq!(cursor.get_remaining().unwrap(), cursor.fill_buf().unwrap());
+    }
+
+    #[test]
+    fn write_cursor() {
+        const SOURCE_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+
+        let mut writer_buffer = [0 as u8; SOURCE_BUFFER.len()];
+        let mut cursor = Cursor::new(writer_buffer.as_mut_slice());
+
+        assert_eq!(cursor.write(SOURCE_BUFFER).unwrap(), SOURCE_BUFFER.len());
+        assert_eq!(cursor.position(), SOURCE_BUFFER.len() as u64);
+    }
+
+    #[test]
+    fn write_buffer_cursor_over() {
+        const SOURCE_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+
+        let mut writer_buffer = [0 as u8; SOURCE_BUFFER.len() / 2];
+        let mut cursor: Cursor<&mut [u8]> = Cursor::new(writer_buffer.as_mut_slice());
+
+        assert_eq!(
+            cursor.write(SOURCE_BUFFER).unwrap(),
+            SOURCE_BUFFER.len() / 2
+        );
+        assert_eq!(
+            SOURCE_BUFFER[..(SOURCE_BUFFER.len() / 2)],
+            **cursor.get_ref()
+        );
+
+        assert_eq!(cursor.write(SOURCE_BUFFER).unwrap(), 0);
+        assert_eq!(
+            cursor.write_all(SOURCE_BUFFER).unwrap_err(),
+            Error::OutOfSpace
+        );
+    }
+
+    #[test]
+    fn write_vec() {
+        const SOURCE_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let mut vec: Vec<u8> = Vec::new();
+
+        assert_eq!(vec.write(SOURCE_BUFFER).unwrap(), SOURCE_BUFFER.len());
+        assert_eq!(SOURCE_BUFFER, vec.as_slice());
+    }
+
+    #[test]
+    fn write_vec_cursor() {
+        const SOURCE_BUFFER: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let mut cursor = Cursor::new(Vec::new());
+
+        assert_eq!(
+            cursor
+                .write(&SOURCE_BUFFER[..(SOURCE_BUFFER.len() / 2)])
+                .unwrap(),
+            SOURCE_BUFFER.len() / 2
+        );
+        assert_eq!(cursor.position() as usize, SOURCE_BUFFER.len() / 2);
+        assert_eq!(
+            cursor.get_ref().as_slice(),
+            &SOURCE_BUFFER[..(SOURCE_BUFFER.len() / 2)]
+        );
+
+        // Move cursor back, then write the source buffer again
+        cursor.set_position(1);
+        assert_eq!(cursor.write(SOURCE_BUFFER).unwrap(), SOURCE_BUFFER.len());
+        assert_eq!(cursor.position() as usize, SOURCE_BUFFER.len() + 1);
+        assert_eq!(cursor.get_ref().as_slice()[0], SOURCE_BUFFER[0]);
+        assert_eq!(&cursor.get_ref().as_slice()[1..], SOURCE_BUFFER);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! Pure-Rust codecs for LZMA, LZMA2, and XZ.
-//! 
-//! Compatible with both `std` and `no_std` environments. In `no_std` mode, the library provides a minimal implementation of IO for reading from
-//! `io::Cursor<&[u8]>` and writing to `io::Cursor<&mut [u8]>`, `io::Cursor<alloc::vec::Vec<u8>>`, and `alloc::vec::Vec<u8>`.
-//! 
+//!
+//! Compatible with both `std` and `no_std` environments. In `no_std` mode, the
+//! library provides a minimal implementation of IO for reading from
+//! `io::Cursor<&[u8]>` and writing to `io::Cursor<&mut [u8]>`,
+//! `io::Cursor<alloc::vec::Vec<u8>>`, and `alloc::vec::Vec<u8>`.
 #![cfg_attr(docsrs, feature(doc_cfg, doc_cfg_hide))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,26 @@
 //! Pure-Rust codecs for LZMA, LZMA2, and XZ.
+//! 
+//! Compatible with both `std` and `no_std` environments. In `no_std` mode, the library provides a minimal implementation of IO for reading from
+//! `io::Cursor<&[u8]>` and writing to `io::Cursor<&mut [u8]>`, `io::Cursor<alloc::vec::Vec<u8>>`, and `alloc::vec::Vec<u8>`.
+//! 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_cfg_hide))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 #[macro_use]
 mod macros;
 
 mod decode;
 mod encode;
-
-pub mod error;
-
 mod util;
 mod xz;
 
-use std::io;
+pub mod error;
+pub mod io;
 
 /// Compression helpers.
 pub mod compress {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,7 +7,7 @@ macro_rules! const_assert {
         impl<$(const $list: $ty,)*> Assert<$($list,)*> {
             const OK: () = {
                 if !($expr) {
-                    ::std::panic!(::std::concat!("assertion failed: ", $message));
+                    ::core::panic!(::core::concat!("assertion failed: ", $message));
                 }
             };
         }

--- a/src/util/vec2d.rs
+++ b/src/util/vec2d.rs
@@ -1,4 +1,6 @@
-use std::ops::{Index, IndexMut};
+use alloc::boxed::Box;
+use alloc::vec;
+use core::ops::{Index, IndexMut};
 
 /// A 2 dimensional matrix in row-major order backed by a contiguous slice.
 #[derive(Debug)]

--- a/src/xz/header.rs
+++ b/src/xz/header.rs
@@ -1,10 +1,12 @@
 //! XZ header.
 
 use crate::decode::util;
-use crate::error;
+use crate::io::ReadBytes;
 use crate::xz::crc::CRC32;
 use crate::xz::StreamFlags;
-use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+use crate::{error, io};
+use alloc::format;
+use byteorder::{BigEndian, LittleEndian};
 
 /// File format magic header signature, see sect. 2.1.1.1.
 pub(crate) const XZ_MAGIC: &[u8] = &[0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00];
@@ -19,7 +21,7 @@ impl StreamHeader {
     /// Parse a Stream Header from a buffered reader.
     pub(crate) fn parse<BR>(input: &mut BR) -> error::Result<Self>
     where
-        BR: std::io::BufRead,
+        BR: io::BufRead,
     {
         if !util::read_tag(input, XZ_MAGIC)? {
             return Err(error::Error::XzError(format!(

--- a/src/xz/mod.rs
+++ b/src/xz/mod.rs
@@ -43,9 +43,7 @@ impl StreamFlags {
         W: io::Write,
     {
         // First byte is currently unused and hard-coded to null.
-        writer
-            .write(&[0x00, self.check_method as u8])
-            .map_err(Into::into)
+        writer.write(&[0x00, self.check_method as u8])
     }
 }
 
@@ -94,7 +92,7 @@ mod test {
     #[test]
     fn test_checkmethod_roundtrip() {
         let mut count_valid = 0;
-        for input in 0..core::u8::MAX {
+        for input in 0..u8::MAX {
             if let Ok(check) = CheckMethod::try_from(input) {
                 let output: u8 = check.into();
                 assert_eq!(input, output);

--- a/src/xz/mod.rs
+++ b/src/xz/mod.rs
@@ -4,8 +4,8 @@
 //!
 //! [spec]: https://tukaani.org/xz/xz-file-format.txt
 
-use crate::error;
-use std::io;
+use crate::{error, io};
+use alloc::format;
 
 pub(crate) mod crc;
 pub(crate) mod footer;
@@ -84,13 +84,17 @@ impl From<CheckMethod> for u8 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use byteorder::{BigEndian, ReadBytesExt};
+    use alloc::vec;
+    use byteorder::BigEndian;
+    use io::ReadBytes;
+
+    #[cfg(feature = "std")]
     use std::io::{Seek, SeekFrom};
 
     #[test]
     fn test_checkmethod_roundtrip() {
         let mut count_valid = 0;
-        for input in 0..std::u8::MAX {
+        for input in 0..core::u8::MAX {
             if let Ok(check) = CheckMethod::try_from(input) {
                 let output: u8 = check.into();
                 assert_eq!(input, output);
@@ -106,11 +110,16 @@ mod test {
             check_method: CheckMethod::Crc32,
         };
 
-        let mut cursor = std::io::Cursor::new(vec![0u8; 2]);
+        let mut cursor = io::Cursor::new(vec![0u8; 2]);
         let len = input.serialize(&mut cursor).unwrap();
         assert_eq!(len, 2);
 
+        #[cfg(not(feature = "std"))]
+        cursor.set_position(0);
+
+        #[cfg(feature = "std")]
         cursor.seek(SeekFrom::Start(0)).unwrap();
+
         let field = cursor.read_u16::<BigEndian>().unwrap();
         let output = StreamFlags::parse(field).unwrap();
         assert_eq!(input, output);

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -1,10 +1,12 @@
 extern crate lzma;
 
+use lzma_rs::io;
+
 #[cfg(feature = "enable_logging")]
 use log::{debug, info};
-use std::io::Read;
 #[cfg(feature = "stream")]
-use std::io::Write;
+use lzma_rs::io::Write;
+use std::io::Read;
 
 /// Utility function to read a file into memory
 fn read_all_file(filename: &str) -> std::io::Result<Vec<u8>> {
@@ -29,7 +31,9 @@ fn round_trip(x: &[u8]) {
 
 fn round_trip_no_options(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::lzma_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
+
+    lzma_rs::lzma_compress(&mut io::BufReader::new(x), &mut compressed).unwrap();
+
     #[cfg(feature = "enable_logging")]
     info!("Compressed {} -> {} bytes", x.len(), compressed.len());
     #[cfg(feature = "enable_logging")]
@@ -45,7 +49,7 @@ fn assert_round_trip_with_options(
 ) {
     let mut compressed: Vec<u8> = Vec::new();
     lzma_rs::lzma_compress_with_options(
-        &mut std::io::BufReader::new(x),
+        &mut io::BufReader::new(x),
         &mut compressed,
         encode_options,
     )
@@ -57,7 +61,7 @@ fn assert_round_trip_with_options(
 
     // test non-streaming decompression
     {
-        let mut bf = std::io::BufReader::new(compressed.as_slice());
+        let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
         let mut decomp: Vec<u8> = Vec::new();
         lzma_rs::lzma_decompress_with_options(&mut bf, &mut decomp, decode_options).unwrap();
         assert_eq!(decomp, x);
@@ -100,7 +104,7 @@ fn round_trip_file(filename: &str) {
 fn assert_decomp_eq(compressed: &[u8], expected: &[u8], compare_to_liblzma: bool) {
     // Test regular decompression.
     {
-        let mut input = std::io::BufReader::new(compressed);
+        let mut input = lzma_rs::io::BufReader::new(compressed);
         let mut decomp: Vec<u8> = Vec::new();
         lzma_rs::lzma_decompress(&mut input, &mut decomp).unwrap();
         assert_eq!(decomp, expected);
@@ -139,7 +143,7 @@ fn decompress_short_header() {
     let _ = env_logger::try_init();
     let mut decomp: Vec<u8> = Vec::new();
     // TODO: compare io::Errors?
-    lzma_rs::lzma_decompress(&mut (b"" as &[u8]), &mut decomp).unwrap();
+    lzma_rs::lzma_decompress(&mut lzma_rs::io::Cursor::new(b"" as &[u8]), &mut decomp).unwrap();
 }
 
 #[test]
@@ -316,7 +320,7 @@ fn memlimit() {
 
     let mut compressed: Vec<u8> = Vec::new();
     lzma_rs::lzma_compress_with_options(
-        &mut std::io::BufReader::new(&data[..]),
+        &mut lzma_rs::io::BufReader::new(&data[..]),
         &mut compressed,
         &encode_options,
     )
@@ -324,7 +328,7 @@ fn memlimit() {
 
     // test non-streaming decompression
     {
-        let mut bf = std::io::BufReader::new(compressed.as_slice());
+        let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
         let mut decomp: Vec<u8> = Vec::new();
         let error = lzma_rs::lzma_decompress_with_options(&mut bf, &mut decomp, &decode_options)
             .unwrap_err();

--- a/tests/lzma2.rs
+++ b/tests/lzma2.rs
@@ -11,12 +11,12 @@ fn read_all_file(filename: &str) -> std::io::Result<Vec<u8>> {
 
 fn round_trip(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::lzma2_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
+    lzma_rs::lzma2_compress(&mut lzma_rs::io::BufReader::new(x), &mut compressed).unwrap();
     #[cfg(feature = "enable_logging")]
     info!("Compressed {} -> {} bytes", x.len(), compressed.len());
     #[cfg(feature = "enable_logging")]
     debug!("Compressed content: {:?}", compressed);
-    let mut bf = std::io::BufReader::new(compressed.as_slice());
+    let mut bf = lzma_rs::io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::lzma2_decompress(&mut bf, &mut decomp).unwrap();
     assert_eq!(decomp, x)

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "enable_logging")]
 use log::{debug, info};
-use std::io::{BufReader, Cursor, Read};
+use lzma_rs::io;
+use std::io::Read;
 
 /// Utility function to read a file into memory
 fn read_all_file(filename: &str) -> std::io::Result<Vec<u8>> {
@@ -11,12 +12,12 @@ fn read_all_file(filename: &str) -> std::io::Result<Vec<u8>> {
 
 fn round_trip(x: &[u8]) {
     let mut compressed: Vec<u8> = Vec::new();
-    lzma_rs::xz_compress(&mut std::io::BufReader::new(x), &mut compressed).unwrap();
+    lzma_rs::xz_compress(&mut io::BufReader::new(x), &mut compressed).unwrap();
     #[cfg(feature = "enable_logging")]
     info!("Compressed {} -> {} bytes", x.len(), compressed.len());
     #[cfg(feature = "enable_logging")]
     debug!("Compressed content: {:?}", compressed);
-    let mut bf = BufReader::new(compressed.as_slice());
+    let mut bf = io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::xz_decompress(&mut bf, &mut decomp).unwrap();
     assert_eq!(decomp, x)
@@ -53,7 +54,9 @@ fn round_trip_files() {
 
 fn decomp_big_file(compfile: &str, plainfile: &str) {
     let expected = read_all_file(plainfile).unwrap();
-    let mut f = BufReader::new(std::fs::File::open(compfile).unwrap());
+    let compressed = read_all_file(compfile).unwrap();
+
+    let mut f = io::BufReader::new(compressed.as_slice());
     let mut decomp: Vec<u8> = Vec::new();
     lzma_rs::xz_decompress(&mut f, &mut decomp).unwrap();
     assert!(decomp == expected)
@@ -86,11 +89,11 @@ fn big_file() {
 fn decompress_empty_world() {
     #[cfg(feature = "enable_logging")]
     let _ = env_logger::try_init();
-    let mut x: &[u8] = b"\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x00\x00\x00\x00\
+    let x: &[u8] = b"\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x00\x00\x00\x00\
                          \x1c\xdf\x44\x21\x1f\xb6\xf3\x7d\x01\x00\x00\x00\x00\x04\x59\x5a\
                          ";
     let mut decomp: Vec<u8> = Vec::new();
-    lzma_rs::xz_decompress(&mut x, &mut decomp).unwrap();
+    lzma_rs::xz_decompress(&mut lzma_rs::io::Cursor::new(x), &mut decomp).unwrap();
     assert_eq!(decomp, b"")
 }
 
@@ -98,13 +101,13 @@ fn decompress_empty_world() {
 fn decompress_hello_world() {
     #[cfg(feature = "enable_logging")]
     let _ = env_logger::try_init();
-    let mut x: &[u8] = b"\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00\x21\x01\
+    let x: &[u8] = b"\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00\x21\x01\
                          \x16\x00\x00\x00\x74\x2f\xe5\xa3\x01\x00\x0b\x48\x65\x6c\x6c\x6f\
                          \x20\x77\x6f\x72\x6c\x64\x0a\x00\xca\xec\x49\x05\x66\x3f\x67\x98\
                          \x00\x01\x24\x0c\xa6\x18\xd8\xd8\x1f\xb6\xf3\x7d\x01\x00\x00\x00\
                          \x00\x04\x59\x5a";
     let mut decomp: Vec<u8> = Vec::new();
-    lzma_rs::xz_decompress(&mut x, &mut decomp).unwrap();
+    lzma_rs::xz_decompress(&mut lzma_rs::io::Cursor::new(x), &mut decomp).unwrap();
     assert_eq!(decomp, b"Hello world\x0a")
 }
 
@@ -132,7 +135,7 @@ fn test_xz_block_check_crc32_invalid() {
         buf[0x55] = 0x45;
         buf[0x56] = 0x23;
         buf[0x57] = 0x01;
-        BufReader::new(Cursor::new(buf))
+        io::BufReader::new(io::Cursor::new(buf))
     };
     let mut decomp = Vec::new();
 


### PR DESCRIPTION
### Pull Request Overview

This change adds support for `no_std` environments that still support the `alloc` crate. To achieve this, all references to `std::io` have been directed to an internal `io` module. In the default case (with the "std" feature flag enabled) the new `io` module simply re-exports relevant `std::io` constructs, leaving all current functionality intact. With the "std" feature flag disabled, `io` implements a minimal set of `std::io`-like constructs that are used as drop-in replacements for the use of `std::io` features in the rest of the crate.

The `no_std` `io` implementation allows any `AsRef<u8>` (including `&[u8]` and `Vec<u8>`) to be used as a `BufRead` by wrapping it in a `io::Cursor` with `io::Cursor::new()`, and `Vec<u8>`, `io::Cursor<Vec<u8>>`, and `io::Cursor<&mut [u8]>` to be used as `Write`.

### Testing Strategy

This pull request was tested by...

- [x] Added relevant unit tests to the `no_std` `io` implementation in `nostd.rs`.
- [x] Modified workflow to run all tests and benchmarks with and without `std` support

### Supporting Documentation and References

Updated Rustdoc and README.md
