### PR TITLE
Add allow_trailing_after_eos option for LZMA decompression

### DIFF
--- a/src/decode/lzma.rs
+++ b/src/decode/lzma.rs
@@ -182,15 +182,21 @@ pub(crate) struct DecoderState {
     rep: [usize; 4],
     len_decoder: LenDecoder,
     rep_len_decoder: LenDecoder,
+    allow_trailing_after_eos: bool,
 }
 
 impl DecoderState {
-    pub fn new(lzma_props: LzmaProperties, unpacked_size: Option<u64>) -> Self {
+    pub fn new(
+        lzma_props: LzmaProperties,
+        unpacked_size: Option<u64>,
+        allow_trailing_after_eos: bool,
+    ) -> Self {
         lzma_props.validate();
         DecoderState {
             partial_input_buf: std::io::Cursor::new([0; MAX_REQUIRED_INPUT]),
             lzma_props,
             unpacked_size,
+            allow_trailing_after_eos,
             literal_probs: Vec2D::init(0x400, (1 << (lzma_props.lc + lzma_props.lp), 0x300)),
             pos_slot_decoder: [
                 BitTree::new(),
@@ -372,7 +378,7 @@ impl DecoderState {
             if update {
                 self.rep[0] = rep_0;
                 if self.rep[0] == 0xFFFF_FFFF {
-                    if rangecoder.is_finished_ok()? {
+                    if self.allow_trailing_after_eos || rangecoder.is_finished_ok()? {
                         return Ok(ProcessingStatus::Finished);
                     }
                     return Err(error::Error::LzmaError(String::from(
@@ -604,11 +610,19 @@ impl LzmaDecoder {
     /// Creates a new object ready for decompressing data that it's given for
     /// the input dict size, expected unpacked data size, and memory limit
     /// for the internal buffer.
-    pub fn new(params: LzmaParams, memlimit: Option<usize>) -> error::Result<LzmaDecoder> {
+    pub fn new(
+        params: LzmaParams,
+        memlimit: Option<usize>,
+        allow_trailing_after_eos: bool,
+    ) -> error::Result<LzmaDecoder> {
         Ok(Self {
             params,
             memlimit: memlimit.unwrap_or(usize::MAX),
-            state: DecoderState::new(params.properties, params.unpacked_size),
+            state: DecoderState::new(
+                params.properties,
+                params.unpacked_size,
+                allow_trailing_after_eos,
+            ),
         })
     }
 

--- a/src/decode/lzma2.rs
+++ b/src/decode/lzma2.rs
@@ -29,6 +29,7 @@ impl Lzma2Decoder {
                     pb: 0,
                 },
                 None,
+                false,
             ),
         }
     }

--- a/src/decode/options.rs
+++ b/src/decode/options.rs
@@ -17,6 +17,14 @@ pub struct Options {
     ///
     /// The default is false (always do completion check).
     pub allow_incomplete: bool,
+    /// Allow trailing bytes after EOS marker without error.
+    ///
+    /// Some formats like NSIS archives have padding or other data after the
+    /// LZMA compressed stream. When this is true, the decoder will not error
+    /// if there are remaining bytes after the end-of-stream marker.
+    ///
+    /// The default is false (strict validation - error if bytes remain).
+    pub allow_trailing_after_eos: bool,
 }
 
 /// Alternatives for defining the unpacked size of the decoded data.
@@ -53,6 +61,7 @@ mod test {
                 unpacked_size: UnpackedSize::ReadFromHeader,
                 memlimit: None,
                 allow_incomplete: false,
+                allow_trailing_after_eos: false,
             },
             Options::default()
         );

--- a/src/decode/stream.rs
+++ b/src/decode/stream.rs
@@ -161,7 +161,11 @@ where
     ) -> crate::error::Result<State<W>> {
         match LzmaParams::read_header(&mut input, options) {
             Ok(params) => {
-                let decoder = DecoderState::new(params.properties, params.unpacked_size);
+                let decoder = DecoderState::new(
+                    params.properties,
+                    params.unpacked_size,
+                    options.allow_trailing_after_eos,
+                );
                 let output = LzCircularBuffer::from_stream(
                     output,
                     params.dict_size as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@ pub fn lzma_decompress_with_options<R: io::BufRead, W: io::Write>(
     options: &decompress::Options,
 ) -> error::Result<()> {
     let params = decode::lzma::LzmaParams::read_header(input, options)?;
-    let mut decoder = decode::lzma::LzmaDecoder::new(params, options.memlimit)?;
+    let mut decoder =
+        decode::lzma::LzmaDecoder::new(params, options.memlimit, options.allow_trailing_after_eos)?;
     decoder.decompress(input, output)
 }
 

--- a/tests/files/.gitattributes
+++ b/tests/files/.gitattributes
@@ -1,0 +1,7 @@
+# Test fixture files must preserve Unix line endings (LF)
+# These are compared byte-for-byte against decompressed output
+# from the corresponding .lzma/.xz files
+
+*.txt text eol=lf
+good-1-lzma2-* text eol=lf
+range-coder-edge-case text eol=lf

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -354,3 +354,95 @@ fn memlimit() {
         );
     }
 }
+
+#[test]
+fn allow_trailing_after_eos() {
+    #[cfg(feature = "enable_logging")]
+    let _ = env_logger::try_init();
+
+    let original = b"Hello, LZMA world! This is a test of trailing bytes handling.";
+
+    // Compress with unknown size (will include EOS marker)
+    let mut compressed = Vec::new();
+    let encode_options = lzma_rs::compress::Options {
+        unpacked_size: lzma_rs::compress::UnpackedSize::WriteToHeader(None),
+    };
+    lzma_rs::lzma_compress_with_options(
+        &mut std::io::BufReader::new(&original[..]),
+        &mut compressed,
+        &encode_options,
+    )
+    .unwrap();
+
+    // Append trailing garbage bytes (simulating NSIS padding)
+    let mut compressed_with_trailing = compressed.clone();
+    compressed_with_trailing.extend_from_slice(b"\x00\x00\x00\x00GARBAGE");
+
+    // Test 1: Default behavior should fail with trailing bytes
+    {
+        let decode_options = lzma_rs::decompress::Options {
+            unpacked_size: lzma_rs::decompress::UnpackedSize::ReadFromHeader,
+            allow_trailing_after_eos: false,
+            ..Default::default()
+        };
+        let mut output = Vec::new();
+        let result = lzma_rs::lzma_decompress_with_options(
+            &mut std::io::BufReader::new(compressed_with_trailing.as_slice()),
+            &mut output,
+            &decode_options,
+        );
+        assert!(
+            result.is_err(),
+            "Should fail with trailing bytes when allow_trailing_after_eos is false"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("end-of-stream"),
+            "Error should mention end-of-stream: {}",
+            err_msg
+        );
+    }
+
+    // Test 2: With allow_trailing_after_eos: true, should succeed
+    {
+        let decode_options = lzma_rs::decompress::Options {
+            unpacked_size: lzma_rs::decompress::UnpackedSize::ReadFromHeader,
+            allow_trailing_after_eos: true,
+            ..Default::default()
+        };
+        let mut output = Vec::new();
+        let result = lzma_rs::lzma_decompress_with_options(
+            &mut std::io::BufReader::new(compressed_with_trailing.as_slice()),
+            &mut output,
+            &decode_options,
+        );
+        assert!(
+            result.is_ok(),
+            "Should succeed with allow_trailing_after_eos: true, got: {:?}",
+            result
+        );
+        assert_eq!(output, original, "Decompressed data should match original");
+    }
+
+    // Test 3: Without trailing bytes, both should work
+    {
+        let decode_options = lzma_rs::decompress::Options::default();
+        let mut output = Vec::new();
+        let result = lzma_rs::lzma_decompress_with_options(
+            &mut std::io::BufReader::new(compressed.as_slice()),
+            &mut output,
+            &decode_options,
+        );
+        assert!(result.is_ok(), "Should succeed without trailing bytes");
+        assert_eq!(output, original);
+    }
+}
+
+#[test]
+fn allow_trailing_after_eos_default() {
+    let options = lzma_rs::decompress::Options::default();
+    assert_eq!(
+        options.allow_trailing_after_eos, false,
+        "allow_trailing_after_eos should default to false for backwards compatibility"
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

Add `allow_trailing_after_eos` option for LZMA decompression

Some formats like NSIS archives have padding or other data after the LZMA compressed stream. Previously, the decoder would error with "Found end-of-stream marker but more bytes are available" when encountering trailing bytes after an EOS marker.

This adds a new `allow_trailing_after_eos` field to `decompress::Options` that allows decompression to succeed even when there are trailing bytes after the EOS marker. The default is `false` to maintain backwards compatibility with strict validation.

Changes:
- Add `allow_trailing_after_eos` field to `Options` struct
- Pass option through `LzmaDecoder` and `DecoderState`
- Make EOS check conditional on the option
- Add tests for the new option
- Add `.gitattributes` to ensure test fixture files preserve Unix line endings (LF). These files are compared byte-for-byte against decompressed output from .lzma/.xz files, so line ending conversion breaks the tests on Windows.

### Testing Strategy

This pull request was tested by...

- [X] Added relevant unit tests.
- [X] Added relevant end-to-end tests (such as `.lzma`, `.lzma2`, `.xz` files).
